### PR TITLE
Update comrak to 0.20.0

### DIFF
--- a/lib/mdex/types/options.ex
+++ b/lib/mdex/types/options.ex
@@ -16,7 +16,8 @@ defmodule MDEx.Types.ParseOptions do
   @moduledoc false
   defstruct smart: false,
             default_info_string: nil,
-            relaxed_tasklist_matching: false
+            relaxed_tasklist_matching: false,
+            relaxed_autolinks: true
 end
 
 defmodule MDEx.Types.RenderOptions do

--- a/native/comrak_nif/Cargo.lock
+++ b/native/comrak_nif/Cargo.lock
@@ -207,11 +207,12 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "comrak"
-version = "0.18.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "482aa5695bca086022be453c700a40c02893f1ba7098a2c88351de55341ae894"
+checksum = "9f18e72341e6cdc7489cffb76f993812a14a906db54dedb020044ccc211dcaae"
 dependencies = [
  "clap",
+ "derive_builder",
  "entities",
  "memchr",
  "once_cell",
@@ -251,12 +252,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+dependencies = [
+ "derive_builder_core",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -383,6 +450,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"

--- a/native/comrak_nif/Cargo.toml
+++ b/native/comrak_nif/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 rustler = "0.29"
 serde = "1.0"
 serde_rustler = { git = "https://github.com/avencera/serde_rustler.git", branch = "rustler-0-29" }
-comrak = "0.18"
+comrak = "0.20"
 ammonia = "3.3"
 phf = { version = "0.11", features = ["macros"] }
 tree-sitter = "0.20"

--- a/native/comrak_nif/src/lib.rs
+++ b/native/comrak_nif/src/lib.rs
@@ -6,8 +6,8 @@ mod types;
 
 use ammonia::clean;
 use comrak::{
-    markdown_to_html, markdown_to_html_with_plugins, ComrakExtensionOptions, ComrakOptions,
-    ComrakParseOptions, ComrakPlugins, ComrakRenderOptions,
+    markdown_to_html, markdown_to_html_with_plugins, ComrakPlugins, ExtensionOptions,
+    ListStyleType, Options, ParseOptions, RenderOptions,
 };
 use inkjet_adapter::InkjetAdapter;
 use rustler::{Env, NifResult, Term};
@@ -21,17 +21,16 @@ fn to_html(md: &str) -> String {
     let inkjet_adapter = InkjetAdapter::new("onedark");
     let mut plugins = ComrakPlugins::default();
     plugins.render.codefence_syntax_highlighter = Some(&inkjet_adapter);
-    markdown_to_html_with_plugins(md, &ComrakOptions::default(), &plugins)
+    markdown_to_html_with_plugins(md, &Options::default(), &plugins)
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
 fn to_html_with_options<'a>(env: Env<'a>, md: &str, options: ExOptions) -> NifResult<Term<'a>> {
-    let comrak_options = ComrakOptions {
-        extension: ComrakExtensionOptions::from(options.extension),
-        parse: ComrakParseOptions::from(options.parse),
-        render: ComrakRenderOptions::from(options.render),
+    let comrak_options = comrak::Options {
+        extension: extension_options_from_ex_options(&options),
+        parse: parse_options_from_ex_options(&options),
+        render: render_options_from_ex_options(&options),
     };
-
     match options.features.syntax_highlight_theme {
         Some(theme) => {
             let inkjet_adapter = InkjetAdapter::new(&theme);
@@ -45,6 +44,49 @@ fn to_html_with_options<'a>(env: Env<'a>, md: &str, options: ExOptions) -> NifRe
             render(env, unsafe_html, options.features.sanitize)
         }
     }
+}
+
+fn extension_options_from_ex_options(options: &ExOptions) -> ExtensionOptions {
+    let mut extension_options = ExtensionOptions::default();
+
+    extension_options.strikethrough = options.extension.strikethrough;
+    extension_options.tagfilter = options.extension.tagfilter;
+    extension_options.table = options.extension.table;
+    extension_options.autolink = options.extension.autolink;
+    extension_options.tasklist = options.extension.tasklist;
+    extension_options.superscript = options.extension.superscript;
+    extension_options.header_ids = options.extension.header_ids.clone();
+    extension_options.footnotes = options.extension.footnotes;
+    extension_options.description_lists = options.extension.description_lists;
+    extension_options.front_matter_delimiter = options.extension.front_matter_delimiter.clone();
+
+    extension_options
+}
+
+fn parse_options_from_ex_options(options: &ExOptions) -> ParseOptions {
+    let mut parse_options = ParseOptions::default();
+
+    parse_options.smart = options.parse.smart;
+    parse_options.default_info_string = options.parse.default_info_string.clone();
+    parse_options.relaxed_tasklist_matching = options.parse.relaxed_tasklist_matching;
+    parse_options.relaxed_autolinks = options.parse.relaxed_autolinks;
+
+    parse_options
+}
+
+fn render_options_from_ex_options(options: &ExOptions) -> RenderOptions {
+    let mut render_options = RenderOptions::default();
+
+    render_options.hardbreaks = options.render.hardbreaks;
+    render_options.github_pre_lang = options.render.github_pre_lang;
+    render_options.full_info_string = options.render.full_info_string;
+    render_options.width = options.render.width;
+    render_options.unsafe_ = options.render.unsafe_;
+    render_options.escape = options.render.escape;
+    render_options.list_style = ListStyleType::from(options.render.list_style.clone());
+    render_options.sourcepos = options.render.sourcepos;
+
+    render_options
 }
 
 fn render(env: Env, unsafe_html: String, sanitize: bool) -> NifResult<Term> {

--- a/native/comrak_nif/src/types/options.rs
+++ b/native/comrak_nif/src/types/options.rs
@@ -1,4 +1,4 @@
-use comrak::{ComrakExtensionOptions, ComrakParseOptions, ComrakRenderOptions, ListStyleType};
+use comrak::ListStyleType;
 
 #[derive(Debug, NifStruct)]
 #[module = "MDEx.Types.ExtensionOptions"]
@@ -15,42 +15,16 @@ pub struct ExExtensionOptions {
     pub front_matter_delimiter: Option<String>,
 }
 
-impl From<ExExtensionOptions> for ComrakExtensionOptions {
-    fn from(options: ExExtensionOptions) -> Self {
-        ComrakExtensionOptions {
-            strikethrough: options.strikethrough,
-            tagfilter: options.tagfilter,
-            table: options.table,
-            autolink: options.autolink,
-            tasklist: options.tasklist,
-            superscript: options.superscript,
-            header_ids: options.header_ids,
-            footnotes: options.footnotes,
-            description_lists: options.description_lists,
-            front_matter_delimiter: options.front_matter_delimiter,
-        }
-    }
-}
-
 #[derive(Debug, NifStruct)]
 #[module = "MDEx.Types.ParseOptions"]
 pub struct ExParseOptions {
     pub smart: bool,
     pub default_info_string: Option<String>,
     pub relaxed_tasklist_matching: bool,
+    pub relaxed_autolinks: bool,
 }
 
-impl From<ExParseOptions> for ComrakParseOptions {
-    fn from(options: ExParseOptions) -> Self {
-        ComrakParseOptions {
-            smart: options.smart,
-            default_info_string: options.default_info_string,
-            relaxed_tasklist_matching: options.relaxed_tasklist_matching,
-        }
-    }
-}
-
-#[derive(Debug, NifUnitEnum)]
+#[derive(Clone, Debug, NifUnitEnum)]
 pub enum ExListStyleType {
     Dash,
     Plus,
@@ -78,21 +52,6 @@ pub struct ExRenderOptions {
     pub escape: bool,
     pub list_style: ExListStyleType,
     pub sourcepos: bool,
-}
-
-impl From<ExRenderOptions> for ComrakRenderOptions {
-    fn from(options: ExRenderOptions) -> Self {
-        ComrakRenderOptions {
-            hardbreaks: options.hardbreaks,
-            github_pre_lang: options.github_pre_lang,
-            full_info_string: options.full_info_string,
-            width: options.width,
-            unsafe_: options.unsafe_,
-            escape: options.escape,
-            list_style: ListStyleType::from(options.list_style),
-            sourcepos: options.sourcepos,
-        }
-    }
 }
 
 #[derive(Debug, NifStruct)]


### PR DESCRIPTION
This PR updates the [`comrak`](https://github.com/kivikakk/comrak) dependency to version 0.20.0. The most significant change here deals with how `ComrakOptions` and related structs are constructed which can no longer use struct expressions due to the addition of `#[non_exhaustive]` (see https://github.com/kivikakk/comrak/pull/305 and https://github.com/kivikakk/comrak/issues/321).