### PR TITLE
Encode, decode, and manipulate AST

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,4 @@
-# Used by "mix format"
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test,examples}/**/*.{ex,exs}"],
+  line_length: 150
 ]

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ mdex-*.tar
 checksum-*.exs
 
 /.elixir_ls/
+
+/examples/*.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.2.0-dev
+
+### Enhancements
+  * Added `parse_document/1` and `parse_document/2` to parse Markdown to AST
+  * Added `traverse_and_update/2` and `attribute/2` to manipulate AST
+  * Added `to_html!/1` and `to_html!/2`
+  * Changed `to_html/1` and `to_html/2` to accept AST as input
+  * Added examples directory to show how to use the new APIs
+
+### Breaking changes
+  * `to_html/1` and `to_html/2` now returns `{:ok, String.t()}` or `{:error, %MDEx.DecodeError{}}` instead of just `String.t()`
+    The reason is because now they may accept an AST as input which may cause decoding errors.
+    Replace with `to_html!/1` and `to_html!/2` to have a similar behavior as before.
+
 ## 0.1.18 (2024-07-13)
 
 ### Enhancements

--- a/examples/alerts.exs
+++ b/examples/alerts.exs
@@ -1,0 +1,116 @@
+Mix.install([
+  {:mdex, path: ".."}
+])
+
+opts = [
+  extension: [autolink: true],
+  render: [unsafe_: true],
+  features: [sanitize: false]
+]
+
+markdown = """
+# Alerts Example
+
+In this example we'll render blockquotes as alerts.
+
+Ref https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts
+
+> [!NOTE]
+> Useful information that users should know, even when skimming content.
+
+> [!CAUTION]
+> Advises about risks or negative outcomes of certain actions.
+"""
+
+note_html = fn content ->
+  """
+  <div class="max-w-md rounded-lg border bg-background p-4 shadow-sm mt-10" role="alert">
+    <div class="flex items-center gap-2">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="12"
+        height="12"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        class="text-blue-500"
+      >
+        <path d="M8 2v4" />
+        <path d="M16 2v4" />
+        <path d="M3 10h18" />
+        <path d="M10 14h4" />
+        <path d="M12 12v6" />
+        <rect width="18" height="18" x="3" y="4" rx="2" />
+      </svg>
+      <h5 class="text-sm font-medium text-blue-500">Note</h5>
+    </div>
+    <p class="mt-2 text-sm text-muted-foreground">
+      #{content}
+    </p>
+  </div>
+  """
+end
+
+caution_html = fn content ->
+  """
+  <div class="max-w-md rounded-lg border border-red-200 bg-red-50 p-4 shadow-sm mt-10" role="alert">
+    <div class="flex items-center gap-2">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="12"
+        height="12"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        class="text-red-500"
+      >
+        <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z" />
+        <path d="M12 9v4" />
+        <path d="M12 17h.01" />
+      </svg>
+      <h5 class="text-sm font-medium text-red-500">Caution</h5>
+    </div>
+    <p class="mt-2 text-sm text-red-700">
+      #{content}
+    </p>
+  </div>
+  """
+end
+
+html =
+  markdown
+  |> MDEx.parse_document!(opts)
+  |> MDEx.traverse_and_update(fn
+    # inject tailwind
+    {"document", attrs, children} ->
+      tailwind =
+        MDEx.parse_document!("""
+        <script src="https://cdn.tailwindcss.com"></script>
+        """)
+
+      {"document", attrs, children ++ tailwind}
+
+    # inject a html block to render a note alert
+    {"block_quote", _attrs, [{"paragraph", [], ["[!NOTE]", _note_attrs, note_content]}]} ->
+      alert = note_html.(note_content)
+      {"html_block", [{"literal", alert}], []}
+
+    # inject a html block to render a caution alert
+    {"block_quote", _attrs, [{"paragraph", [], ["[!CAUTION]", _note_attrs, note_content]}]} ->
+      alert = caution_html.(note_content)
+      {"html_block", [{"literal", alert}], []}
+
+    node ->
+      node
+  end)
+  |> MDEx.to_html!(opts)
+
+File.write!("alerts.html", html)
+
+IO.puts(html)

--- a/examples/mermaid.exs
+++ b/examples/mermaid.exs
@@ -1,0 +1,65 @@
+Mix.install([
+  {:mdex, path: ".."}
+])
+
+opts = [
+  render: [unsafe_: true],
+  features: [sanitize: false]
+]
+
+markdown = """
+# Mermaid Example
+
+In this example we'll inject the script code to initialize and render mermaid blocks.
+
+```mermaid
+sequenceDiagram
+    participant Alice
+    participant Bob
+    Alice->>John: Hello John, how are you?
+    loop HealthCheck
+        John->>John: Fight against hypochondria
+    end
+    Note right of John: Rational thoughts <br/>prevail!
+    John-->>Alice: Great!
+    John->>Bob: How about you?
+    Bob-->>John: Jolly good!
+```
+"""
+
+mermaid = """
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
+  mermaid.initialize({ startOnLoad: true });
+</script>
+"""
+
+html =
+  markdown
+  |> MDEx.parse_document!(opts)
+  |> MDEx.traverse_and_update(fn
+    # inject the script at the end of the document
+    {"document", attrs, children} ->
+      mermaid = MDEx.parse_document!(mermaid)
+      {"document", attrs, children ++ mermaid}
+
+    # inject the mermaid <pre> block without escaping the content
+    {"code_block", _attrs, children} = node ->
+      [code] = MDEx.attribute(node, "literal")
+
+      code = """
+      <pre class="mermaid">
+        #{code}
+      </pre>
+      """
+
+      {"html_block", [{"literal", code}], children}
+
+    node ->
+      node
+  end)
+  |> MDEx.to_html!(opts)
+
+File.write!("mermaid.html", html)
+
+IO.puts(html)

--- a/lib/mdex.ex
+++ b/lib/mdex.ex
@@ -8,21 +8,117 @@ defmodule MDEx do
 
   alias MDEx.Native
 
+  @typedoc """
+  The AST (Abstract Syntax Tree) representation of a markdown document.
+
+  It's composed by a list of nodes and usually the root node is a `document` element.
+  """
+  @type md_ast :: [md_node()]
+
+  @typedoc """
+  Each node of the AST can be either an element or a text.
+  """
+  @type md_node :: md_element() | md_text()
+
+  @typedoc """
+  Elements are composed by a name, a list of attributes and a list of children.
+
+  ## Example
+
+      {"heading", [{"level", 1}, {"setext", false}], children}
+  """
+  @type md_element :: {name :: String.t(), attributes :: [md_attribute()], children :: [md_node()]}
+
+  @typedoc """
+  Attributes of node elements are key-value pairs where key is always a string and value can be of multiple different types.
+
+  ## Examples
+
+      {"level", 1}
+      {"delimiter", "period"}
+  """
+  @type md_attribute :: {String.t(), term()}
+
+  @typedoc """
+  Text element. It has no attributes or children so it's represented just as a string.
+  """
+  @type md_text :: String.t()
+
   @doc """
-  Convert `markdown` to HTML.
+  Parse a `markdown` binary and returns the AST.
+
+  ## Example
+
+      iex> MDEx.parse_document!("# Languages\\n Elixir and Rust")
+      [
+        {"document", [], [
+          {"heading", [{"level", 1}, {"setext", false}], ["Languages"]},
+          {"paragraph", [], ["Elixir and Rust"]}
+        ]}
+      ]
+
+      iex> MDEx.parse_document!("Darth Vader is ||Luke's father||", extension: [spoiler: true])
+      [
+        {"document", [], [
+          {"paragraph", [], [
+            "Darth Vader is ",
+            {"spoilered_text", [], ["Luke's father"]}
+        ]}]}
+      ]
+
+  """
+  @spec parse_document(String.t()) :: {:ok, md_ast()} | {:error, term()}
+  def parse_document(markdown, opts \\ []) do
+    Native.parse_document(markdown, comrak_options(opts))
+  end
+
+  @doc """
+  Same as `parse_document/2` but raises if the parsing fails.
+  """
+  @spec parse_document!(String.t()) :: md_ast()
+  def parse_document!(markdown, opts \\ []) do
+    case Native.parse_document(markdown, comrak_options(opts)) do
+      {:ok, ast} -> ast
+      {:error, error} -> raise error
+    end
+  end
+
+  @doc """
+  Convert either markdown or an AST to HTML using default options.
+
+  To customize the output, use `to_html/2`.
 
   ## Examples
 
       iex> MDEx.to_html("# MDEx")
-      "<h1>MDEx</h1>\\n"
+      {:ok, "<h1>MDEx</h1>\\n"}
 
       iex> MDEx.to_html("Implemented with:\\n1. Elixir\\n2. Rust")
-      "<p>Implemented with:</p>\\n<ol>\\n<li>Elixir</li>\\n<li>Rust</li>\\n</ol>\\n"
+      {:ok, "<p>Implemented with:</p>\\n<ol>\\n<li>Elixir</li>\\n<li>Rust</li>\\n</ol>\\n"}
 
   """
-  @spec to_html(String.t()) :: String.t()
-  def to_html(markdown) when is_binary(markdown) do
-    Native.to_html(markdown)
+  @spec to_html(md_or_ast :: String.t() | md_ast()) :: {:ok, String.t()} | {:error, MDEx.DecodeError.t()}
+  def to_html(md_or_ast)
+
+  def to_html(md_or_ast) when is_binary(md_or_ast) do
+    Native.markdown_to_html(md_or_ast)
+  end
+
+  def to_html(md_or_ast) when is_list(md_or_ast) do
+    md_or_ast
+    |> maybe_wrap_document()
+    |> Native.ast_to_html()
+  end
+
+  @doc """
+  Same as `to_html/1` but raises `MDEx.DecodeError` if the conversion fails.
+  """
+  @spec to_html!(md_or_ast :: String.t() | md_ast()) :: String.t()
+  def to_html!(md_or_ast) do
+    case to_html(md_or_ast) do
+      {:ok, html} -> html
+      {:error, error} -> raise error
+    end
   end
 
   @doc """
@@ -30,52 +126,162 @@ defmodule MDEx do
 
   ## Options
 
-  Accepts all available [Comrak Options](https://docs.rs/comrak/latest/comrak/struct.Options.html) as keyword lists and an extra `:features` option:
-
-  * `:extension` - https://docs.rs/comrak/latest/comrak/struct.ExtensionOptions.html
-  * `:parse` - https://docs.rs/comrak/latest/comrak/struct.ParseOptions.html
-  * `:render` - https://docs.rs/comrak/latest/comrak/struct.RenderOptions.html
-  * `:features` - see the available options below
-
-  ### Features Options
-
-  * `:sanitize` (default `false`) - sanitize output using [ammonia](https://crates.io/crates/ammonia).\n Recommended if passing `render: [unsafe_: true]`
-  * `:syntax_highlight_theme` (default `"onedark"`) - syntax highlight code fences using [autumn themes](https://github.com/leandrocp/autumn/tree/main/priv/themes),
-  you should pass the filename without special chars and without extension, for example you should pass `syntax_highlight_theme: "adwaita_dark"` to use the [Adwaita Dark](https://github.com/leandrocp/autumn/blob/main/priv/themes/adwaita-dark.toml) theme
-  * `:syntax_highlight_inline_style` (default `true`) - embed styles in the output for each generated token. You'll need to [serve CSS themes](https://github.com/leandrocp/autumn?tab=readme-ov-file#linked) if inline styles are disabled to properly highlight code
+  See the [Options](#module-options) section for the available options.
 
   ## Examples
 
-      iex> MDEx.to_html("# MDEx")
-      "<h1>MDEx</h1>\\n"
-
-      iex> MDEx.to_html("Implemented with:\\n1. Elixir\\n2. Rust")
-      "<p>Implemented with:</p>\\n<ol>\\n<li>Elixir</li>\\n<li>Rust</li>\\n</ol>\\n"
-
       iex> MDEx.to_html("Hello ~world~ there", extension: [strikethrough: true])
-      "<p>Hello <del>world</del> there</p>\\n"
+      {:ok, "<p>Hello <del>world</del> there</p>\\n"}
 
       iex> MDEx.to_html("<marquee>visit https://https://beaconcms.org</marquee>", extension: [autolink: true], render: [unsafe_: true])
-      "<p><marquee>visit <a href=\\"https://https://beaconcms.org\\">https://https://beaconcms.org</a></marquee></p>\\n"
+      {:ok, "<p><marquee>visit <a href=\\"https://https://beaconcms.org\\">https://https://beaconcms.org</a></marquee></p>\\n"}
 
       iex> MDEx.to_html("# Title with <script>console.log('dangerous script')</script>", render: [unsafe_: true], features: [sanitize: true])
-      "<h1>Title with </h1>\\n"
+      {:ok, "<h1>Title with </h1>\\n"}
 
   """
-  @spec to_html(String.t(), keyword()) :: String.t()
-  def to_html(markdown, opts) when is_binary(markdown) do
+  @spec to_html(md_or_ast :: String.t() | md_ast(), keyword()) :: String.t()
+  def to_html(md_or_ast, opts)
+
+  def to_html(md_or_ast, opts) when is_binary(md_or_ast) and is_list(opts) do
+    md_or_ast
+    |> Native.markdown_to_html_with_options(comrak_options(opts))
+    |> maybe_wrap_error()
+  end
+
+  def to_html(md_or_ast, opts) when is_list(md_or_ast) and is_list(opts) do
+    md_or_ast
+    |> maybe_wrap_document()
+    |> Native.ast_to_html_with_options(comrak_options(opts))
+    |> maybe_wrap_error()
+  end
+
+  @doc """
+  Same as `to_html/2` but raises `MDEx.DecodeError` if the conversion fails.
+  """
+  @spec to_html!(md_or_ast :: String.t() | md_ast(), keyword()) :: String.t()
+  def to_html!(md_or_ast, opts) do
+    case to_html(md_or_ast, opts) do
+      {:ok, html} -> html
+      {:error, error} -> raise error
+    end
+  end
+
+  defp comrak_options(opts) do
     extension = Keyword.get(opts, :extension, %{})
     parse = Keyword.get(opts, :parse, %{})
     render = Keyword.get(opts, :render, %{})
     features = Keyword.get(opts, :features, %{})
 
-    opts = %MDEx.Types.Options{
+    %MDEx.Types.Options{
       extension: struct(MDEx.Types.ExtensionOptions, extension),
       parse: struct(MDEx.Types.ParseOptions, parse),
       render: struct(MDEx.Types.RenderOptions, render),
       features: struct(MDEx.Types.FeaturesOptions, features)
     }
+  end
 
-    Native.to_html_with_options(markdown, opts)
+  # TODO: check if comrak is able to format ast without wrapping it in a document
+  defp maybe_wrap_document([{"document", _, _} | _] = tree), do: tree
+
+  defp maybe_wrap_document([fragment]) when is_tuple(fragment) do
+    [{"document", [], [fragment]}]
+  end
+
+  defp maybe_wrap_document(fragment) when is_list(fragment) do
+    Enum.all?(fragment, &is_binary/1) ||
+      raise """
+      expected a list of nodes as [{"paragraph", [], ["text"]}] or ["text"]
+
+      Got:
+
+        #{inspect(fragment)}
+
+      """
+
+    [{"document", [], [{"paragraph", [], fragment}]}]
+  end
+
+  defp maybe_wrap_error({:ok, result}), do: {:ok, result}
+  defp maybe_wrap_error({:error, {reason, found}}), do: {:error, %MDEx.DecodeError{reason: reason, found: found}}
+  defp maybe_wrap_error({:error, {reason, found, node}}), do: {:error, %MDEx.DecodeError{reason: reason, found: found, node: node}}
+  defp maybe_wrap_error({:error, {reason, found, node, kind}}), do: {:error, %MDEx.DecodeError{reason: reason, found: found, node: node, kind: kind}}
+
+  defp maybe_wrap_error({:error, {reason, found, node, attr, kind}}),
+    do: {:error, %MDEx.DecodeError{reason: reason, found: found, node: node, attr: attr, kind: kind}}
+
+  @doc """
+  Traverses and updates a Markdown AST.
+
+  ## Examples
+
+      iex> ast = [{"document", [], [{"heading", [{"level", 1}, {"setext", false}], ["Hello"]}]}]
+      iex> MDEx.traverse_and_update(ast, fn
+      ...>   {"heading", _attrs, children} -> {"heading", [{"level", 2}], children}
+      ...>   other -> other
+      ...> end)
+      [{"document", [], [{"heading", [{"level", 2}], ["Hello"]}]}]
+
+  See more on the [examples](https://github.com/leandrocp/mdex/tree/main/examples) directory.
+  """
+  @spec traverse_and_update(
+          md_node() | md_ast(),
+          (md_node() -> md_node() | [md_node()] | nil)
+        ) :: md_node() | md_ast()
+  defdelegate traverse_and_update(ast, fun), to: MDEx.Traversal
+
+  # https://github.com/philss/floki/blob/28c9ed8d10d851b63ec87fb8ab9c5acd3c7ea90c/lib/floki.ex#L670
+  @doc """
+  Returns a list with attribute values for a given `attribute_name`.
+
+  ## Example
+
+      iex> MDEx.attribute({
+      ...>   "code_block",
+      ...>   [{"info", "mermaid"}, {"literal", "graph TD;\\n  A-->B;"}],
+      ...>   []
+      ...> }, "literal")
+      ["graph TD;\\n  A-->B;"]
+
+  """
+  @spec attribute(md_ast() | md_node(), String.t()) :: list()
+  def attribute(ast_or_node, attribute_name) do
+    attribute_values(ast_or_node, attribute_name)
+  end
+
+  defp attribute_values(element, attr_name) when is_tuple(element) do
+    attribute_values([element], attr_name)
+  end
+
+  defp attribute_values(elements, attr_name) do
+    values =
+      Enum.reduce(
+        elements,
+        [],
+        fn
+          {_, attributes, _}, acc ->
+            case attribute_match?(attributes, attr_name) do
+              {_attr_name, value} ->
+                [value | acc]
+
+              _ ->
+                acc
+            end
+
+          _, acc ->
+            acc
+        end
+      )
+
+    Enum.reverse(values)
+  end
+
+  defp attribute_match?(attributes, attribute_name) do
+    Enum.find(
+      attributes,
+      fn {attr_name, _} ->
+        attr_name == attribute_name
+      end
+    )
   end
 end

--- a/lib/mdex/errors.ex
+++ b/lib/mdex/errors.ex
@@ -1,0 +1,189 @@
+defmodule MDEx.DecodeError do
+  @moduledoc """
+  Represents an error decoding the AST from the Elixir data structure into Rust.
+
+  This module is defined as an exception so a message can be generated calling `Exception.message/1`
+  or it can be raised.
+
+  ## Fields
+
+    * `:reason` - an atom representing the type of decode error:
+
+        * `:invalid_structure` - AST structure is invalid or malformed.
+
+        * `:empty` - AST is empty, no nodes found.
+
+        * `:missing_node_field` - one or more fields of a node is missing, it should contain `{name, attributes, children}`.
+
+        * `:missing_attr_field` - either the key or value of an attribute is missing.
+
+        * `:node_name_not_string` - node name is not a UTF-8 encoded string.
+
+        * `:unknown_node_name` - node name is not one of the available node names.
+
+        * `:attr_key_not_string` - attribute key is not a UTF-8 encoded string.
+
+        * `:unknown_attr_value` - attribute value doesn't match any expected type.
+
+    * `:found` - the source that caused the error, either the node or attribute.
+        Most of the times it's displayed as the raw [Term](https://docs.rs/rustler/latest/rustler/struct.Term.html) value as a string (debug).
+        That's because the error may be caused by malformed or unexpected data and we can't decode it to a human-readable format.
+
+    * `:node` - the node where the error was found, usually when the error is in an attribute or children.
+
+    * `:attr` - the attribute where the error was found.
+
+    * `:kind` - the type of the field that caused the error.
+
+  """
+
+  defexception [:reason, :found, :node, :attr, :kind]
+
+  @type t() :: %__MODULE__{
+          reason: atom(),
+          found: String.t(),
+          node: nil | String.t(),
+          attr: nil | String.t(),
+          kind: nil | String.t()
+        }
+
+  def message(%__MODULE__{reason: :invalid_structure, found: found}) do
+    """
+    AST structure is invalid or malformed.
+
+    Expected a list of nodes in the format [{name :: binary(), attributes :: [{name :: binary(), value :: term()}], children :: [node()]}]
+
+    Got:
+
+      #{found}
+
+    """
+  end
+
+  def message(%__MODULE__{reason: :empty, found: found}) do
+    """
+    AST is empty, no nodes found.
+
+    Expected a list of nodes in the format [{name :: binary(), attributes :: [{name :: binary(), value :: term()}], children :: [node()]}]
+
+    Got:
+
+      #{found}
+
+    """
+  end
+
+  def message(%__MODULE__{reason: :missing_node_field, found: found}) do
+    """
+    missing one or more fields in the node.
+
+    Expected a list of nodes in the format {name :: binary(), attributes :: [{name :: binary(), value :: term()}], children :: [node()]}
+
+    Got:
+
+      #{found}
+
+    """
+  end
+
+  def message(%__MODULE__{reason: :missing_attr_field, found: found, node: node}) do
+    """
+    missing either the key or value in the attribute.
+
+    Expected an attribute in the format {name :: String.t(), value :: term()}
+
+    Got:
+
+      #{found}
+
+    In this node:
+
+      #{node}
+
+    """
+  end
+
+  def message(%__MODULE__{reason: :node_name_not_string, found: found, node: node, kind: kind}) do
+    """
+    invalid node name
+
+    Expected a node name encoded as UTF-8 binary
+
+    Got:
+
+      #{found}
+
+    Type:
+
+      #{kind}
+
+    In this node:
+
+      #{node}
+
+    """
+  end
+
+  def message(%__MODULE__{reason: :unknown_node_name, node: node, found: found}) do
+    """
+    unknown node name
+
+    Expected one of the available node names listed at https://docs.rs/comrak/latest/comrak/nodes/enum.NodeValue.html
+
+    Got:
+
+      #{found}
+
+    In this node:
+
+      #{node}
+
+    """
+  end
+
+  def message(%__MODULE__{reason: :attr_key_not_string, found: found, node: node, attr: attr, kind: kind}) do
+    """
+    invalid attribute key
+
+    Expected an attribute key encoded as UTF-8 binary
+
+    Got:
+
+      #{found}
+
+    Type:
+
+      #{kind}
+
+    In this node:
+
+      #{node}
+
+    In this attribute:
+
+      #{attr}
+
+    """
+  end
+
+  def message(%__MODULE__{reason: :unknown_attr_value, found: found, node: node, attr: attr}) do
+    """
+    unknown attribute value
+
+    Attribute value doesn't match any expected type.
+
+    Got:
+
+      #{found}
+
+    In this node:
+
+      #{node}
+
+    In this attribute:
+
+      #{attr}
+
+    """
+  end
+end

--- a/lib/mdex/native.ex
+++ b/lib/mdex/native.ex
@@ -53,6 +53,9 @@ defmodule MDEx.Native do
     mode: mode,
     force_build: System.get_env("MDEX_BUILD") in ["1", "true"]
 
-  def to_html(_md), do: :erlang.nif_error(:nif_not_loaded)
-  def to_html_with_options(_md, _options), do: :erlang.nif_error(:nif_not_loaded)
+  def markdown_to_html(_md), do: :erlang.nif_error(:nif_not_loaded)
+  def markdown_to_html_with_options(_md, _options), do: :erlang.nif_error(:nif_not_loaded)
+  def parse_document(_md, _options), do: :erlang.nif_error(:nif_not_loaded)
+  def ast_to_html(_ast), do: :erlang.nif_error(:nif_not_loaded)
+  def ast_to_html_with_options(_ast, _options), do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/lib/mdex/traversal.ex
+++ b/lib/mdex/traversal.ex
@@ -1,0 +1,66 @@
+# https://github.com/philss/floki/blob/28c9ed8d10d851b63ec87fb8ab9c5acd3c7ea90c/lib/floki/traversal.ex
+defmodule MDEx.Traversal do
+  @moduledoc false
+
+  def traverse_and_update(html_node, fun)
+  def traverse_and_update([], _fun), do: []
+  def traverse_and_update(text, _fun) when is_binary(text), do: text
+  def traverse_and_update({:pi, _, _} = xml_tag, fun), do: fun.(xml_tag)
+  def traverse_and_update({:comment, _children} = comment, fun), do: fun.(comment)
+  def traverse_and_update({:doctype, _, _, _} = doctype, fun), do: fun.(doctype)
+
+  def traverse_and_update([head | tail], fun) do
+    case traverse_and_update(head, fun) do
+      nil ->
+        traverse_and_update(tail, fun)
+
+      mapped_head ->
+        mapped_tail = traverse_and_update(tail, fun)
+
+        mapped =
+          if is_list(mapped_head) do
+            mapped_head ++ mapped_tail
+          else
+            [mapped_head | mapped_tail]
+          end
+
+        mapped
+    end
+  end
+
+  def traverse_and_update({elem, attrs, children}, fun) do
+    mapped_children = traverse_and_update(children, fun)
+    fun.({elem, attrs, mapped_children})
+  end
+
+  def traverse_and_update(html_node, acc, fun)
+  def traverse_and_update([], acc, _fun), do: {[], acc}
+  def traverse_and_update(text, acc, _fun) when is_binary(text), do: {text, acc}
+  def traverse_and_update({:pi, _, _} = xml_tag, acc, fun), do: fun.(xml_tag, acc)
+  def traverse_and_update({:comment, _children} = comment, acc, fun), do: fun.(comment, acc)
+  def traverse_and_update({:doctype, _, _, _} = doctype, acc, fun), do: fun.(doctype, acc)
+
+  def traverse_and_update([head | tail], acc, fun) do
+    case traverse_and_update(head, acc, fun) do
+      {nil, new_acc} ->
+        traverse_and_update(tail, new_acc, fun)
+
+      {mapped_head, new_acc} ->
+        {mapped_tail, new_acc2} = traverse_and_update(tail, new_acc, fun)
+
+        mapped =
+          if is_list(mapped_head) do
+            mapped_head ++ mapped_tail
+          else
+            [mapped_head | mapped_tail]
+          end
+
+        {mapped, new_acc2}
+    end
+  end
+
+  def traverse_and_update({elem, attrs, children}, acc, fun) do
+    {mapped_children, new_acc} = traverse_and_update(children, acc, fun)
+    fun.({elem, attrs, mapped_children}, new_acc)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule MDEx.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/leandrocp/mdex"
-  @version "0.1.19-dev"
+  @version "0.2.0-dev"
   @dev? String.ends_with?(@version, "-dev")
   @force_build? System.get_env("MDEX_BUILD") in ["1", "true"]
 
@@ -18,8 +18,7 @@ defmodule MDEx.MixProject do
       aliases: aliases(),
       name: "MDEx",
       homepage_url: "https://github.com/leandrocp/mdex",
-      description:
-        "A fast 100% CommonMark-compatible GitHub Flavored Markdown parser and formatter."
+      description: "A CommonMark-compliant fast and extensible Markdown parser and formatter."
     ]
   end
 
@@ -46,11 +45,13 @@ defmodule MDEx.MixProject do
         native/comrak_nif/.cargo
         native/comrak_nif/Cargo.*
         native/comrak_nif/Cross.toml
-        checksum-Elixir.MDEx.Native.exs
+        examples
         mix.exs
+        benchmark.exs
         README.md
         LICENSE.md
         CHANGELOG.md
+        checksum-Elixir.MDEx.Native.exs
       ]
     ]
   end

--- a/native/comrak_nif/Cargo.lock
+++ b/native/comrak_nif/Cargo.lock
@@ -249,6 +249,8 @@ dependencies = [
  "autumn",
  "comrak",
  "inkjet",
+ "lazy_static",
+ "log",
  "phf",
  "rustler",
  "serde",
@@ -514,6 +516,12 @@ name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -1086,18 +1094,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.62"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2675633b1499176c2dff06b0856a27976a8f9d436737b4cf4f312d4d91d8bbb"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.62"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d20468752b09f49e909e55a5d338caa8bedf615594e9d80bc4c565d30faf798c"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/native/comrak_nif/Cargo.toml
+++ b/native/comrak_nif/Cargo.toml
@@ -22,6 +22,9 @@ phf = { version = "0.11", features = ["macros"] }
 tree-sitter = "0.20"
 tree-sitter-highlight = "0.20"
 v_htmlescape = "0.15"
+autumn = { path = "vendor/autumn" }
+log = "0.4"
+lazy_static = "1.5"
 inkjet = { version = "0.10.5", default-features = false, features = [
     "html",
     "language-bash",
@@ -78,7 +81,6 @@ inkjet = { version = "0.10.5", default-features = false, features = [
     "language-yaml",
     "language-zig",
 ] }
-autumn = { path = "vendor/autumn" }
 
 [features]
 default = ["nif_version_2_15"]

--- a/native/comrak_nif/src/decoder.rs
+++ b/native/comrak_nif/src/decoder.rs
@@ -1,0 +1,708 @@
+use crate::types::{
+    atoms::{
+        attr_key_not_string, empty, invalid_structure, missing_attr_field, missing_node_field,
+        node_name_not_string, unknown_attr_value, unknown_node_name,
+    },
+    nodes::{AttrValue, ExNode, NodeName},
+};
+use comrak::{
+    nodes::{
+        AstNode, ListDelimType, ListType, NodeCode, NodeCodeBlock, NodeDescriptionItem,
+        NodeFootnoteDefinition, NodeFootnoteReference, NodeHeading, NodeHtmlBlock, NodeLink,
+        NodeList, NodeMath, NodeMultilineBlockQuote, NodeShortCode, NodeTable, NodeValue,
+        NodeWikiLink, TableAlignment,
+    },
+    Arena,
+};
+use rustler::{Binary, Decoder, Encoder, Env, Error, NifResult, Term};
+use std::str::FromStr;
+
+#[derive(Debug)]
+pub enum DecodeError {
+    InvalidStructure {
+        found: String,
+    },
+    Empty {
+        found: String,
+    },
+    MissingNodeField {
+        found: String,
+    },
+    MissingAttrField {
+        found: String,
+        node: String,
+    },
+    NodeNameNotString {
+        found: String,
+        node: String,
+        kind: String,
+    },
+    UnknownNodeName {
+        found: String,
+        node: String,
+    },
+    AttrKeyNotString {
+        found: String,
+        node: String,
+        attr: String,
+        kind: String,
+    },
+    UnknownAttrValue {
+        found: String,
+        node: String,
+        attr: String,
+        kind: String,
+    },
+}
+
+impl Encoder for DecodeError {
+    fn encode<'a>(&self, env: Env<'a>) -> Term<'a> {
+        match self {
+            DecodeError::InvalidStructure { found } => {
+                let reason = invalid_structure().encode(env);
+                (reason, found).encode(env)
+            }
+            DecodeError::Empty { found } => {
+                let reason = empty().encode(env);
+                (reason, found).encode(env)
+            }
+            DecodeError::MissingNodeField { found } => {
+                let reason = missing_node_field().encode(env);
+                (reason, found).encode(env)
+            }
+            DecodeError::MissingAttrField { found, node } => {
+                let reason = missing_attr_field().encode(env);
+                (reason, found, node).encode(env)
+            }
+            DecodeError::NodeNameNotString { found, node, kind } => {
+                let reason = node_name_not_string().encode(env);
+                (reason, found, node, kind).encode(env)
+            }
+            DecodeError::UnknownNodeName { found, node } => {
+                let reason = unknown_node_name().encode(env);
+                (reason, found, node).encode(env)
+            }
+            DecodeError::AttrKeyNotString {
+                found,
+                node,
+                attr,
+                kind,
+            } => {
+                let reason = attr_key_not_string().encode(env);
+                (reason, found, node, attr, kind).encode(env)
+            }
+            DecodeError::UnknownAttrValue {
+                found,
+                node,
+                attr,
+                kind,
+            } => {
+                let reason = unknown_attr_value().encode(env);
+                (reason, found, node, attr, kind).encode(env)
+            }
+        }
+    }
+}
+
+impl From<DecodeError> for Error {
+    fn from(err: DecodeError) -> Error {
+        Error::Term(Box::new(err))
+    }
+}
+
+impl<'a> Decoder<'a> for ExNode<'a> {
+    fn decode(term: Term<'a>) -> NifResult<Self> {
+        let list: Vec<Term> = term.decode().map_err(|_| DecodeError::InvalidStructure {
+            found: format!("{:?}", term),
+        })?;
+
+        if list.len() != 1 {
+            return Err(DecodeError::Empty {
+                found: format!("{:?}", term),
+            }
+            .into());
+        }
+
+        decode_node(&list[0])
+    }
+}
+
+fn decode_node<'a>(term: &Term<'a>) -> NifResult<ExNode<'a>> {
+    if let Ok(text) = term.decode::<String>() {
+        return Ok(ExNode::Text(text));
+    }
+
+    let node: (Term, Term, Term) = term.decode().map_err(|_| DecodeError::MissingNodeField {
+        found: format!("{:?}", term),
+    })?;
+
+    let name = node
+        .0
+        .decode::<Binary>()
+        .map_err(|_| DecodeError::NodeNameNotString {
+            found: format!("{:?}", node.0),
+            node: format!("{:?}", node),
+            kind: format!("{:?}", rustler::Term::get_type(node.0)),
+        })?;
+    let name =
+        std::str::from_utf8(name.as_slice()).map_err(|_| DecodeError::NodeNameNotString {
+            found: format!("{:?}", node.0),
+            node: format!("{:?}", node),
+            kind: format!("{:?}", rustler::Term::get_type(node.0)),
+        })?;
+    let name = NodeName::from_str(name).map_err(|_| DecodeError::UnknownNodeName {
+        found: name.to_string(),
+        node: format!("{:?}", node),
+    })?;
+
+    let attrs: Vec<(Term, Term)> = node.1.decode().map_err(|_| DecodeError::MissingAttrField {
+        found: format!("{:?}", node.1),
+        node: format!("{:?}", node),
+    })?;
+
+    let attrs = attrs
+        .into_iter()
+        .map(|(key, value)| {
+            let key_binary: Binary = key.decode().map_err(|_| DecodeError::AttrKeyNotString {
+                found: format!("{:?}", key),
+                node: format!("{:?}", node),
+                attr: format!("{:?}", (key, value)),
+                kind: format!("{:?}", rustler::Term::get_type(key)),
+            })?;
+            let key = std::str::from_utf8(key_binary.as_slice()).map_err(|_| {
+                DecodeError::AttrKeyNotString {
+                    found: format!("{:?}", key),
+                    node: format!("{:?}", node),
+                    attr: format!("{:?}", (key, value)),
+                    kind: format!("{:?}", rustler::Term::get_type(key)),
+                }
+            })?;
+
+            let attr_value: AttrValue =
+                value.decode().map_err(|_| DecodeError::UnknownAttrValue {
+                    found: format!("{:?}", value),
+                    node: format!("{:?}", node),
+                    attr: format!("{:?}", (key, value)),
+                    kind: format!("{:?}", rustler::Term::get_type(value)),
+                })?;
+
+            Ok((key, attr_value))
+        })
+        .collect::<Result<Vec<_>, Error>>()?;
+
+    let children: Vec<Term> = node.2.decode().map_err(|_| DecodeError::InvalidStructure {
+        found: format!("E7 {:?}", node.1),
+    })?;
+
+    let children = children
+        .into_iter()
+        .map(|child_term| decode_node(&child_term))
+        .collect::<Result<Vec<_>, Error>>()?;
+
+    Ok(ExNode::Element {
+        name,
+        attrs,
+        children,
+    })
+}
+
+pub fn ex_node_to_comrak_ast<'a>(
+    arena: &'a Arena<AstNode<'a>>,
+    ex_node: &ExNode,
+) -> &'a AstNode<'a> {
+    match ex_node {
+        ExNode::Element {
+            name,
+            attrs,
+            children,
+        } => {
+            // println!("name: {:?}", name);
+            // println!("attrs: {:?}", attrs);
+
+            let node_value = match name {
+                NodeName::Document => AstNode::from(NodeValue::Document),
+                NodeName::FrontMatter => {
+                    let mut front_matter = NodeValue::FrontMatter("".to_string());
+
+                    for (key, value) in attrs {
+                        match (key, value) {
+                            (&"content", AttrValue::Text(ref value)) => {
+                                front_matter = NodeValue::FrontMatter(value.clone())
+                            }
+                            (attr_name, attr_value) => {
+                                unknown_attr("front_matter", attr_name, attr_value)
+                            }
+                        }
+                    }
+
+                    AstNode::from(front_matter)
+                }
+                NodeName::BlockQuote => AstNode::from(NodeValue::BlockQuote),
+                NodeName::List => {
+                    AstNode::from(NodeValue::List(attrs_to_node_list("list", attrs.to_vec())))
+                }
+                NodeName::Item => {
+                    AstNode::from(NodeValue::Item(attrs_to_node_list("item", attrs.to_vec())))
+                }
+                NodeName::DescriptionList => AstNode::from(NodeValue::DescriptionList),
+                NodeName::DescriptionItem => {
+                    let mut node = NodeDescriptionItem::default();
+
+                    for (key, value) in attrs {
+                        match (key, value) {
+                            (&"marker_offset", AttrValue::Usize(ref value)) => {
+                                node.marker_offset = *value
+                            }
+                            (&"marker_offset", AttrValue::U8(ref value)) => {
+                                node.marker_offset = *value as usize
+                            }
+                            (&"padding", AttrValue::Usize(ref value)) => node.padding = *value,
+                            (&"padding", AttrValue::U8(ref value)) => {
+                                node.padding = *value as usize
+                            }
+                            (attr_name, attr_value) => {
+                                unknown_attr("description_item", attr_name, attr_value)
+                            }
+                        }
+                    }
+
+                    AstNode::from(NodeValue::DescriptionItem(node))
+                }
+                NodeName::DescriptionTerm => AstNode::from(NodeValue::DescriptionTerm),
+                NodeName::DescriptionDetails => AstNode::from(NodeValue::DescriptionDetails),
+                NodeName::CodeBlock => {
+                    let mut node = NodeCodeBlock::default();
+
+                    for (key, value) in attrs {
+                        match (key, value) {
+                            (&"fenced", AttrValue::Bool(ref value)) => node.fenced = *value,
+                            (&"fence_char", AttrValue::Text(ref value)) => {
+                                node.fence_char = string_to_char(value.clone())
+                            }
+                            (&"fence_length", AttrValue::Usize(ref value)) => {
+                                node.fence_length = *value
+                            }
+                            (&"fence_length", AttrValue::U8(ref value)) => {
+                                node.fence_length = *value as usize
+                            }
+                            (&"fence_offset", AttrValue::Usize(ref value)) => {
+                                node.fence_offset = *value
+                            }
+                            (&"fence_offset", AttrValue::U8(ref value)) => {
+                                node.fence_offset = *value as usize
+                            }
+                            (&"info", AttrValue::Text(ref value)) => node.info = value.clone(),
+                            (&"literal", AttrValue::Text(ref value)) => {
+                                node.literal = value.clone()
+                            }
+                            (attr_name, attr_value) => {
+                                unknown_attr("code_block", attr_name, attr_value)
+                            }
+                        }
+                    }
+
+                    AstNode::from(NodeValue::CodeBlock(node))
+                }
+                NodeName::HtmlBlock => {
+                    let mut node = NodeHtmlBlock::default();
+
+                    for (key, value) in attrs {
+                        match (key, value) {
+                            (&"block_type", AttrValue::U8(ref value)) => node.block_type = *value,
+                            (&"literal", AttrValue::Text(ref value)) => {
+                                node.literal = value.clone()
+                            }
+                            (attr_name, att_value) => {
+                                unknown_attr("html_block", attr_name, att_value)
+                            }
+                        }
+                    }
+
+                    AstNode::from(NodeValue::HtmlBlock(node))
+                }
+                NodeName::Paragraph => AstNode::from(NodeValue::Paragraph),
+                NodeName::Heading => {
+                    let mut node = NodeHeading {
+                        level: 1,
+                        setext: false,
+                    };
+
+                    for (key, value) in attrs {
+                        match (key, value) {
+                            (&"level", AttrValue::U8(ref value)) => node.level = *value,
+                            (&"setext", AttrValue::Bool(ref value)) => node.setext = *value,
+                            (attr_name, attr_value) => {
+                                unknown_attr("heading", attr_name, attr_value)
+                            }
+                        }
+                    }
+
+                    AstNode::from(NodeValue::Heading(node))
+                }
+                NodeName::ThematicBreak => AstNode::from(NodeValue::ThematicBreak),
+                NodeName::FootnoteDefinition => {
+                    let mut node = NodeFootnoteDefinition::default();
+
+                    for (key, value) in attrs {
+                        match (key, value) {
+                            (&"name", AttrValue::Text(ref value)) => node.name = value.clone(),
+                            (&"total_references", AttrValue::U32(ref value)) => {
+                                node.total_references = *value
+                            }
+                            (&"total_references", AttrValue::U8(ref value)) => {
+                                node.total_references = *value as u32
+                            }
+                            (attr_name, attr_value) => {
+                                unknown_attr("footnote_definition", attr_name, attr_value)
+                            }
+                        }
+                    }
+
+                    AstNode::from(NodeValue::FootnoteDefinition(node))
+                }
+                NodeName::FootnoteReference => {
+                    let mut node = NodeFootnoteReference::default();
+
+                    for (key, value) in attrs {
+                        match (key, value) {
+                            (&"name", AttrValue::Text(ref value)) => node.name = value.clone(),
+                            (&"ref_num", AttrValue::U32(ref value)) => node.ref_num = *value,
+                            (&"ref_num", AttrValue::U8(ref value)) => node.ref_num = *value as u32,
+                            (&"ix", AttrValue::U32(ref value)) => node.ix = *value,
+                            (&"ix", AttrValue::U8(ref value)) => node.ix = *value as u32,
+                            (attr_name, attr_value) => {
+                                unknown_attr("footnote_reference", attr_name, attr_value)
+                            }
+                        }
+                    }
+
+                    AstNode::from(NodeValue::FootnoteReference(node))
+                }
+                NodeName::Table => {
+                    let mut node = NodeTable::default();
+
+                    for (key, value) in attrs {
+                        match (key, value) {
+                            (&"alignments", AttrValue::List(ref value)) => {
+                                let alignments = value
+                                    .iter()
+                                    .map(|ta| match ta.as_str() {
+                                        "none" => TableAlignment::None,
+                                        "left" => TableAlignment::Left,
+                                        "center" => TableAlignment::Center,
+                                        "right" => TableAlignment::Right,
+                                        _ => TableAlignment::None,
+                                    })
+                                    .collect::<Vec<TableAlignment>>();
+
+                                node.alignments = alignments
+                            }
+                            (&"num_columns", AttrValue::Usize(ref value)) => {
+                                node.num_columns = *value
+                            }
+                            (&"num_columns", AttrValue::U8(ref value)) => {
+                                node.num_columns = *value as usize
+                            }
+                            (&"num_rows", AttrValue::Usize(ref value)) => node.num_rows = *value,
+                            (&"num_rows", AttrValue::U8(ref value)) => {
+                                node.num_rows = *value as usize
+                            }
+                            (&"num_nonempty_cells", AttrValue::Usize(ref value)) => {
+                                node.num_nonempty_cells = *value
+                            }
+                            (&"num_nonempty_cells", AttrValue::U8(ref value)) => {
+                                node.num_nonempty_cells = *value as usize
+                            }
+                            (attr_name, attr_value) => unknown_attr("table", attr_name, attr_value),
+                        }
+                    }
+
+                    AstNode::from(NodeValue::Table(node))
+                }
+                NodeName::TableRow => {
+                    let mut table_row = NodeValue::TableRow(false);
+
+                    for (key, value) in attrs {
+                        match (key, value) {
+                            (&"header", AttrValue::Bool(ref value)) => {
+                                table_row = NodeValue::TableRow(*value)
+                            }
+                            (attr_name, attr_value) => {
+                                unknown_attr("table_row", attr_name, attr_value)
+                            }
+                        }
+                    }
+
+                    AstNode::from(table_row)
+                }
+                NodeName::TableCell => AstNode::from(NodeValue::TableCell),
+                NodeName::TaskItem => AstNode::from(NodeValue::TaskItem(attrs_to_task_item(
+                    "task_item",
+                    attrs.to_vec(),
+                ))),
+                NodeName::SoftBreak => AstNode::from(NodeValue::SoftBreak),
+                NodeName::LineBreak => AstNode::from(NodeValue::LineBreak),
+                NodeName::Code => {
+                    let mut node = NodeCode {
+                        num_backticks: 0,
+                        literal: "".to_string(),
+                    };
+
+                    for (key, value) in attrs {
+                        match (key, value) {
+                            (&"num_backticks", AttrValue::Usize(ref value)) => {
+                                node.num_backticks = *value
+                            }
+                            (&"num_backticks", AttrValue::U8(ref value)) => {
+                                node.num_backticks = *value as usize
+                            }
+                            (&"literal", AttrValue::Text(ref value)) => {
+                                node.literal = value.clone()
+                            }
+                            (attr_name, attr_value) => unknown_attr("code", attr_name, attr_value),
+                        }
+                    }
+
+                    AstNode::from(NodeValue::Code(node))
+                }
+                NodeName::HtmlInline => {
+                    let mut html_inline = NodeValue::HtmlInline("".to_string());
+
+                    for (key, value) in attrs {
+                        match (key, value) {
+                            (&"raw_html", AttrValue::Text(ref value)) => {
+                                html_inline = NodeValue::HtmlInline(value.clone())
+                            }
+                            (attr_name, attr_value) => {
+                                unknown_attr("html_inline", attr_name, attr_value)
+                            }
+                        }
+                    }
+
+                    AstNode::from(html_inline)
+                }
+                NodeName::Emph => AstNode::from(NodeValue::Emph),
+                NodeName::Strong => AstNode::from(NodeValue::Strong),
+                NodeName::Strikethrough => AstNode::from(NodeValue::Strikethrough),
+                NodeName::Superscript => AstNode::from(NodeValue::Superscript),
+                NodeName::Link => {
+                    AstNode::from(NodeValue::Link(attrs_to_node_link("link", attrs.to_vec())))
+                }
+                NodeName::Image => AstNode::from(NodeValue::Image(attrs_to_node_link(
+                    "image",
+                    attrs.to_vec(),
+                ))),
+                NodeName::ShortCode => {
+                    let mut node = NodeShortCode {
+                        code: "".to_string(),
+                        emoji: "".to_string(),
+                    };
+
+                    for (key, value) in attrs {
+                        match (key, value) {
+                            (&"code", AttrValue::Text(ref value)) => node.code = value.clone(),
+                            (&"emoji", AttrValue::Text(ref value)) => node.emoji = value.clone(),
+                            (attr_name, attr_value) => {
+                                unknown_attr("short_code", attr_name, attr_value)
+                            }
+                        }
+                    }
+
+                    AstNode::from(NodeValue::ShortCode(node))
+                }
+                NodeName::Math => {
+                    let mut node = NodeMath {
+                        dollar_math: false,
+                        display_math: false,
+                        literal: "".to_string(),
+                    };
+
+                    for (key, value) in attrs {
+                        match (key, value) {
+                            (&"dollar_math", AttrValue::Bool(ref value)) => {
+                                node.dollar_math = *value
+                            }
+                            (&"display_math", AttrValue::Bool(ref value)) => {
+                                node.display_math = *value
+                            }
+                            (&"literal", AttrValue::Text(ref value)) => {
+                                node.literal = value.clone()
+                            }
+                            (attr_name, attr_value) => unknown_attr("math", attr_name, attr_value),
+                        }
+                    }
+
+                    AstNode::from(NodeValue::Math(node))
+                }
+                NodeName::MultilineBlockQuote => {
+                    let mut node = NodeMultilineBlockQuote {
+                        fence_length: 0,
+                        fence_offset: 0,
+                    };
+
+                    for (key, value) in attrs {
+                        match (key, value) {
+                            (&"fence_length", AttrValue::Usize(ref value)) => {
+                                node.fence_length = *value
+                            }
+                            (&"fence_length", AttrValue::U8(ref value)) => {
+                                node.fence_length = *value as usize
+                            }
+                            (&"fence_offset", AttrValue::Usize(ref value)) => {
+                                node.fence_offset = *value
+                            }
+                            (&"fence_offset", AttrValue::U8(ref value)) => {
+                                node.fence_offset = *value as usize
+                            }
+                            (attr_name, attr_value) => {
+                                unknown_attr("multiline_block_quote", attr_name, attr_value)
+                            }
+                        }
+                    }
+
+                    AstNode::from(NodeValue::MultilineBlockQuote(node))
+                }
+                NodeName::Escaped => AstNode::from(NodeValue::Escaped),
+                NodeName::WikiLink => {
+                    let mut node = NodeWikiLink {
+                        url: "".to_string(),
+                    };
+
+                    for (key, value) in attrs {
+                        match (key, value) {
+                            (&"url", AttrValue::Text(ref value)) => node.url = value.clone(),
+                            (attr_name, attr_value) => {
+                                unknown_attr("wiki_link", attr_name, attr_value)
+                            }
+                        }
+                    }
+
+                    AstNode::from(NodeValue::WikiLink(node))
+                }
+                NodeName::Underline => AstNode::from(NodeValue::Underline),
+                NodeName::SpoileredText => AstNode::from(NodeValue::SpoileredText),
+                NodeName::EscapedTag => {
+                    let mut escaped_tag = NodeValue::EscapedTag("".to_string());
+
+                    for (key, value) in attrs {
+                        match (key, value) {
+                            (&"tag", AttrValue::Text(ref value)) => {
+                                escaped_tag = NodeValue::EscapedTag(value.clone())
+                            }
+                            (attr_name, attr_value) => {
+                                unknown_attr("escaped_tag", attr_name, attr_value)
+                            }
+                        }
+                    }
+
+                    AstNode::from(escaped_tag)
+                }
+            };
+
+            let node = arena.alloc(node_value);
+
+            for child in children {
+                let child_node = ex_node_to_comrak_ast(arena, child);
+                node.append(child_node);
+            }
+
+            node
+        }
+        ExNode::Text(content) => {
+            let text = AstNode::from(NodeValue::Text(content.clone()));
+            arena.alloc(text)
+        }
+    }
+}
+
+fn string_to_char(s: String) -> u8 {
+    if s.is_empty() {
+        return 0;
+    }
+
+    s.chars().next().unwrap_or(' ') as u8
+}
+
+fn unknown_attr(node_name: &str, attr_name: &str, attr_value: &AttrValue) {
+    log::warn!(
+        "unknown attribute {} on node {} with value {:?}",
+        attr_name,
+        node_name,
+        attr_value
+    );
+}
+
+fn attrs_to_node_list(node_name: &str, attrs: Vec<(&str, AttrValue)>) -> NodeList {
+    let mut list = NodeList::default();
+
+    let to_list_type = |value: &str| -> ListType {
+        match value {
+            "bullet" => ListType::Bullet,
+            "ordered" => ListType::Ordered,
+            _ => ListType::default(),
+        }
+    };
+
+    let to_delim_type = |value: &str| -> ListDelimType {
+        match value {
+            "period" => ListDelimType::Period,
+            "paren" => ListDelimType::Paren,
+            _ => ListDelimType::default(),
+        }
+    };
+
+    for (key, value) in attrs {
+        match (key, value) {
+            ("list_type", AttrValue::Text(ref value)) => {
+                list.list_type = to_list_type(value.as_str())
+            }
+            ("marker_offset", AttrValue::Usize(ref value)) => list.marker_offset = *value,
+            ("marker_offset", AttrValue::U8(ref value)) => list.marker_offset = *value as usize,
+            ("padding", AttrValue::Usize(ref value)) => list.padding = *value,
+            ("padding", AttrValue::U8(ref value)) => list.padding = *value as usize,
+            ("start", AttrValue::Usize(ref value)) => list.start = *value,
+            ("start", AttrValue::U8(ref value)) => list.start = *value as usize,
+            ("delimiter", AttrValue::Text(ref value)) => {
+                list.delimiter = to_delim_type(value.as_str())
+            }
+            ("bullet_char", AttrValue::Text(ref value)) => {
+                list.bullet_char = string_to_char(value.clone())
+            }
+            ("tight", AttrValue::Bool(ref value)) => list.tight = *value,
+            (attr_name, attr_value) => unknown_attr(node_name, attr_name, &attr_value),
+        }
+    }
+
+    list
+}
+
+fn attrs_to_task_item(node_name: &str, attrs: Vec<(&str, AttrValue)>) -> Option<char> {
+    let mut symbol = None;
+
+    for (key, value) in attrs {
+        match (key, value) {
+            ("checked", AttrValue::Bool(false)) => return None,
+            ("symbol", AttrValue::Text(ref value)) => symbol = value.chars().next(),
+            (attr_name, attr_value) => unknown_attr(node_name, attr_name, &attr_value),
+        }
+    }
+
+    symbol
+}
+
+fn attrs_to_node_link(node_name: &str, attrs: Vec<(&str, AttrValue)>) -> NodeLink {
+    let mut link = NodeLink {
+        url: "".to_string(),
+        title: "".to_string(),
+    };
+
+    for (key, value) in attrs {
+        match (key, value) {
+            ("url", AttrValue::Text(ref value)) => link.url = value.clone(),
+            ("title", AttrValue::Text(ref value)) => link.title = value.clone(),
+            (attr_name, attr_value) => unknown_attr(node_name, attr_name, &attr_value),
+        }
+    }
+
+    link
+}

--- a/native/comrak_nif/src/encoder.rs
+++ b/native/comrak_nif/src/encoder.rs
@@ -1,0 +1,301 @@
+use crate::types::nodes::{AttrValue, ExNode, NodeName};
+use comrak::nodes::{
+    AstNode, ListDelimType, ListType, NodeLink, NodeList, NodeValue, TableAlignment,
+};
+use rustler::{Encoder, Env, Term};
+
+impl Encoder for NodeName {
+    fn encode<'a>(&self, env: Env<'a>) -> Term<'a> {
+        match self {
+            Self::Document => "document",
+            Self::FrontMatter => "front_matter",
+            Self::BlockQuote => "block_quote",
+            Self::List => "list",
+            Self::Item => "item",
+            Self::DescriptionList => "description_list",
+            Self::DescriptionItem => "description_item",
+            Self::DescriptionTerm => "description_term",
+            Self::DescriptionDetails => "description_details",
+            Self::CodeBlock => "code_block",
+            Self::HtmlBlock => "html_block",
+            Self::Paragraph => "paragraph",
+            Self::Heading => "heading",
+            Self::ThematicBreak => "themantic_break",
+            Self::FootnoteDefinition => "footnote_definition",
+            Self::Table => "table",
+            Self::TableRow => "table_row",
+            Self::TableCell => "table_cell",
+            Self::TaskItem => "task_item",
+            Self::SoftBreak => "soft_break",
+            Self::LineBreak => "line_break",
+            Self::Code => "code",
+            Self::HtmlInline => "html_inline",
+            Self::Emph => "emph",
+            Self::Strong => "strong",
+            Self::Strikethrough => "strikethrough",
+            Self::Superscript => "superscript",
+            Self::Link => "link",
+            Self::Image => "image",
+            Self::FootnoteReference => "footnote_reference",
+            Self::ShortCode => "short_code",
+            Self::Math => "math",
+            Self::MultilineBlockQuote => "multiline_block_quote",
+            Self::Escaped => "escaped",
+            Self::WikiLink => "wiki_link",
+            Self::Underline => "underline",
+            Self::SpoileredText => "spoilered_text",
+            Self::EscapedTag => "escaped_tag",
+        }
+        .encode(env)
+    }
+}
+
+impl<'a> Encoder for ExNode<'a> {
+    fn encode<'b>(&self, env: Env<'b>) -> Term<'b> {
+        match self {
+            Self::Text(text) => text.encode(env),
+
+            Self::Element {
+                name,
+                attrs,
+                children,
+            } => {
+                let mut attr_list = Vec::new();
+
+                for (key, value) in attrs {
+                    let attr_value = match value {
+                        AttrValue::U8(v) => (key, v.encode(env)),
+                        AttrValue::U32(v) => (key, v.encode(env)),
+                        AttrValue::Usize(v) => (key, v.encode(env)),
+                        AttrValue::Bool(v) => (key, v.encode(env)),
+                        AttrValue::Text(v) => (key, v.encode(env)),
+                        AttrValue::List(v) => (key, v.encode(env)),
+                    };
+
+                    attr_list.push(attr_value);
+                }
+
+                (name, attr_list, children).encode(env)
+            }
+        }
+    }
+}
+
+pub fn to_elixir_ast<'a>(node: &'a AstNode<'a>) -> ExNode {
+    let node_data = node.data.borrow();
+
+    match node_data.value {
+        NodeValue::Text(ref text) => ExNode::Text(text.to_string()),
+        _ => {
+            let (name, attrs) = match node_data.value {
+                NodeValue::Document => (NodeName::Document, vec![]),
+                NodeValue::FrontMatter(ref content) => (
+                    NodeName::FrontMatter,
+                    vec![("content", AttrValue::Text(content.to_owned()))],
+                ),
+                NodeValue::BlockQuote => (NodeName::BlockQuote, vec![]),
+                NodeValue::List(ref attrs) => (NodeName::List, node_list_to_ast(attrs)),
+                NodeValue::Item(ref attrs) => (NodeName::Item, node_list_to_ast(attrs)),
+                NodeValue::DescriptionList => (NodeName::DescriptionList, vec![]),
+                NodeValue::DescriptionItem(ref attrs) => (
+                    NodeName::DescriptionItem,
+                    vec![
+                        ("marker_offset", AttrValue::Usize(attrs.marker_offset)),
+                        ("padding", AttrValue::Usize(attrs.padding)),
+                    ],
+                ),
+                NodeValue::DescriptionTerm => (NodeName::DescriptionTerm, vec![]),
+                NodeValue::DescriptionDetails => (NodeName::DescriptionDetails, vec![]),
+                NodeValue::CodeBlock(ref attrs) => (
+                    NodeName::CodeBlock,
+                    vec![
+                        ("fenced", AttrValue::Bool(attrs.fenced)),
+                        (
+                            "fence_char",
+                            AttrValue::Text(char_to_string(attrs.fence_char).unwrap_or_default()),
+                        ),
+                        ("fence_length", AttrValue::Usize(attrs.fence_length)),
+                        ("fence_offset", AttrValue::Usize(attrs.fence_offset)),
+                        ("info", AttrValue::Text(attrs.info.to_owned())),
+                        ("literal", AttrValue::Text(attrs.literal.to_owned())),
+                    ],
+                ),
+                NodeValue::HtmlBlock(ref attrs) => (
+                    NodeName::HtmlBlock,
+                    vec![
+                        ("block_type", AttrValue::U8(attrs.block_type)),
+                        ("literal", AttrValue::Text(attrs.literal.to_owned())),
+                    ],
+                ),
+                NodeValue::Paragraph => (NodeName::Paragraph, vec![]),
+                NodeValue::Heading(ref attrs) => (
+                    NodeName::Heading,
+                    vec![
+                        ("level", AttrValue::U8(attrs.level)),
+                        ("setext", AttrValue::Bool(attrs.setext)),
+                    ],
+                ),
+                NodeValue::ThematicBreak => (NodeName::ThematicBreak, vec![]),
+                NodeValue::FootnoteDefinition(ref attrs) => (
+                    NodeName::FootnoteDefinition,
+                    vec![
+                        ("name", AttrValue::Text(attrs.name.to_owned())),
+                        ("total_references", AttrValue::U32(attrs.total_references)),
+                    ],
+                ),
+                NodeValue::FootnoteReference(ref attrs) => (
+                    NodeName::FootnoteReference,
+                    vec![
+                        ("name", AttrValue::Text(attrs.name.to_owned())),
+                        ("ref_num", AttrValue::U32(attrs.ref_num)),
+                        ("ix", AttrValue::U32(attrs.ix)),
+                    ],
+                ),
+                NodeValue::Table(ref attrs) => {
+                    let alignments = attrs
+                        .alignments
+                        .iter()
+                        .map(|ta| match ta {
+                            TableAlignment::None => "none".to_string(),
+                            TableAlignment::Left => "left".to_string(),
+                            TableAlignment::Center => "center".to_string(),
+                            TableAlignment::Right => "right".to_string(),
+                        })
+                        .collect::<Vec<String>>();
+
+                    (
+                        NodeName::Table,
+                        vec![
+                            ("alignments", AttrValue::List(alignments)),
+                            ("num_columns", AttrValue::Usize(attrs.num_columns)),
+                            ("num_rows", AttrValue::Usize(attrs.num_rows)),
+                            (
+                                "num_nonempty_cells",
+                                AttrValue::Usize(attrs.num_nonempty_cells),
+                            ),
+                        ],
+                    )
+                }
+                NodeValue::TableRow(ref header) => (
+                    NodeName::TableRow,
+                    vec![("header", AttrValue::Bool(*header))],
+                ),
+                NodeValue::TableCell => (NodeName::TableCell, vec![]),
+                NodeValue::TaskItem(ref symbol) => (
+                    NodeName::TaskItem,
+                    match symbol {
+                        Some(symbol) => vec![
+                            ("checked", AttrValue::Bool(true)),
+                            ("symbol", AttrValue::Text(symbol.to_string())),
+                        ],
+                        None => vec![("checked", AttrValue::Bool(false))],
+                    },
+                ),
+                NodeValue::SoftBreak => (NodeName::SoftBreak, vec![]),
+                NodeValue::LineBreak => (NodeName::LineBreak, vec![]),
+                NodeValue::Code(ref attrs) => (
+                    NodeName::Code,
+                    vec![
+                        ("num_backticks", AttrValue::Usize(attrs.num_backticks)),
+                        ("literal", AttrValue::Text(attrs.literal.to_owned())),
+                    ],
+                ),
+                NodeValue::HtmlInline(ref raw_html) => (
+                    NodeName::HtmlInline,
+                    vec![("raw_html", AttrValue::Text(raw_html.to_owned()))],
+                ),
+                NodeValue::Emph => (NodeName::Emph, vec![]),
+                NodeValue::Strong => (NodeName::Strong, vec![]),
+                NodeValue::Strikethrough => (NodeName::Strikethrough, vec![]),
+                NodeValue::Superscript => (NodeName::Superscript, vec![]),
+                NodeValue::Link(ref attrs) => (NodeName::Link, node_link_to_ast(attrs)),
+                NodeValue::Image(ref attrs) => (NodeName::Image, node_link_to_ast(attrs)),
+                NodeValue::ShortCode(ref attrs) => (
+                    NodeName::ShortCode,
+                    vec![
+                        ("code", AttrValue::Text(attrs.code.to_owned())),
+                        ("emoji", AttrValue::Text(attrs.emoji.to_owned())),
+                    ],
+                ),
+                NodeValue::Math(ref attrs) => (
+                    NodeName::Math,
+                    vec![
+                        ("dollar_math", AttrValue::Bool(attrs.dollar_math)),
+                        ("display_math", AttrValue::Bool(attrs.display_math)),
+                        ("literal", AttrValue::Text(attrs.literal.to_owned())),
+                    ],
+                ),
+                NodeValue::MultilineBlockQuote(ref attrs) => (
+                    NodeName::MultilineBlockQuote,
+                    vec![
+                        ("fence_length", AttrValue::Usize(attrs.fence_length)),
+                        ("fence_offset", AttrValue::Usize(attrs.fence_offset)),
+                    ],
+                ),
+                NodeValue::Escaped => (NodeName::Escaped, vec![]),
+                NodeValue::WikiLink(ref attrs) => (
+                    NodeName::WikiLink,
+                    vec![("url", AttrValue::Text(attrs.url.to_owned()))],
+                ),
+                NodeValue::Underline => (NodeName::Underline, vec![]),
+                NodeValue::SpoileredText => (NodeName::SpoileredText, vec![]),
+                NodeValue::EscapedTag(ref tag) => (
+                    NodeName::EscapedTag,
+                    vec![("tag", AttrValue::Text(tag.to_owned()))],
+                ),
+                NodeValue::Text(_) => unreachable!(),
+            };
+
+            let children = node.children().map(to_elixir_ast).collect();
+
+            ExNode::Element {
+                name,
+                attrs,
+                children,
+            }
+        }
+    }
+}
+
+fn node_list_to_ast<'a>(list: &NodeList) -> Vec<(&'a str, AttrValue)> {
+    let list_type = match list.list_type {
+        ListType::Bullet => "bullet",
+        ListType::Ordered => "ordered",
+    };
+
+    let delimiter = match list.delimiter {
+        ListDelimType::Period => "period",
+        ListDelimType::Paren => "paren",
+    };
+
+    vec![
+        ("list_type", AttrValue::Text(list_type.to_owned())),
+        ("marker_offset", AttrValue::Usize(list.marker_offset)),
+        ("padding", AttrValue::Usize(list.padding)),
+        ("start", AttrValue::Usize(list.start)),
+        ("delimiter", AttrValue::Text(delimiter.to_owned())),
+        (
+            "bullet_char",
+            AttrValue::Text(char_to_string(list.bullet_char).unwrap_or_default()),
+        ),
+        ("tight", AttrValue::Bool(list.tight)),
+    ]
+}
+
+fn node_link_to_ast<'a>(link: &NodeLink) -> Vec<(&'a str, AttrValue)> {
+    vec![
+        ("url", AttrValue::Text(link.url.to_owned())),
+        ("title", AttrValue::Text(link.title.to_owned())),
+    ]
+}
+
+fn char_to_string(c: u8) -> Result<String, &'static str> {
+    if c == 0 {
+        return Ok("".to_string());
+    }
+
+    match String::from_utf8(vec![c]) {
+        Ok(s) => Ok(s),
+        Err(_) => Err("failed to convert to string"),
+    }
+}

--- a/native/comrak_nif/src/lib.rs
+++ b/native/comrak_nif/src/lib.rs
@@ -1,35 +1,54 @@
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
 #[macro_use]
 extern crate rustler;
 
+mod decoder;
+mod encoder;
 mod inkjet_adapter;
 mod types;
 
 use ammonia::clean;
-use comrak::{
-    markdown_to_html, markdown_to_html_with_plugins, ComrakPlugins, ExtensionOptions,
-    ListStyleType, Options, ParseOptions, RenderOptions,
-};
+use comrak::{markdown_to_html_with_plugins, Arena, ComrakPlugins, Options};
+use decoder::ex_node_to_comrak_ast;
+use encoder::to_elixir_ast;
 use inkjet_adapter::InkjetAdapter;
-use rustler::{Env, NifResult, Term};
-use types::options::*;
+use rustler::{Decoder, Encoder, Env, NifResult, Term};
+use types::{atoms::ok, options::*};
 
-rustler::init!("Elixir.MDEx.Native", [to_html, to_html_with_options]);
+rustler::init!(
+    "Elixir.MDEx.Native",
+    [
+        parse_document,
+        markdown_to_html,
+        markdown_to_html_with_options,
+        ast_to_html,
+        ast_to_html_with_options
+    ]
+);
 
 #[rustler::nif(schedule = "DirtyCpu")]
-fn to_html(md: &str) -> String {
+fn markdown_to_html<'a>(env: Env<'a>, md: &str) -> NifResult<Term<'a>> {
     let inkjet_adapter = InkjetAdapter::default();
     let mut plugins = ComrakPlugins::default();
     plugins.render.codefence_syntax_highlighter = Some(&inkjet_adapter);
-    markdown_to_html_with_plugins(md, &Options::default(), &plugins)
+    let html = markdown_to_html_with_plugins(md, &Options::default(), &plugins);
+    Ok((ok(), html).encode(env))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-fn to_html_with_options<'a>(env: Env<'a>, md: &str, options: ExOptions) -> NifResult<Term<'a>> {
+fn markdown_to_html_with_options<'a>(
+    env: Env<'a>,
+    md: &str,
+    options: ExOptions,
+) -> NifResult<Term<'a>> {
     let comrak_options = comrak::Options {
         extension: extension_options_from_ex_options(&options),
         parse: parse_options_from_ex_options(&options),
         render: render_options_from_ex_options(&options),
     };
+
     match &options.features.syntax_highlight_theme {
         Some(theme) => {
             let inkjet_adapter = InkjetAdapter::new(
@@ -42,84 +61,99 @@ fn to_html_with_options<'a>(env: Env<'a>, md: &str, options: ExOptions) -> NifRe
             let mut plugins = ComrakPlugins::default();
             plugins.render.codefence_syntax_highlighter = Some(&inkjet_adapter);
             let unsafe_html = markdown_to_html_with_plugins(md, &comrak_options, &plugins);
-            render(env, unsafe_html, options.features.sanitize)
+            maybe_sanitize(env, unsafe_html, options.features.sanitize)
         }
         None => {
-            let unsafe_html = markdown_to_html(md, &comrak_options);
-            render(env, unsafe_html, options.features.sanitize)
+            let unsafe_html = comrak::markdown_to_html(md, &comrak_options);
+            maybe_sanitize(env, unsafe_html, options.features.sanitize)
         }
     }
 }
 
-fn extension_options_from_ex_options(options: &ExOptions) -> ExtensionOptions {
-    let mut extension_options = ExtensionOptions::default();
-
-    extension_options.strikethrough = options.extension.strikethrough;
-    extension_options.tagfilter = options.extension.tagfilter;
-    extension_options.table = options.extension.table;
-    extension_options.autolink = options.extension.autolink;
-    extension_options.tasklist = options.extension.tasklist;
-    extension_options.superscript = options.extension.superscript;
-    extension_options
-        .header_ids
-        .clone_from(&options.extension.header_ids);
-    extension_options.footnotes = options.extension.footnotes;
-    extension_options.description_lists = options.extension.description_lists;
-    extension_options
-        .front_matter_delimiter
-        .clone_from(&options.extension.front_matter_delimiter);
-    extension_options.multiline_block_quotes = options.extension.multiline_block_quotes;
-    extension_options.math_dollars = options.extension.math_dollars;
-    extension_options.math_code = options.extension.math_code;
-    extension_options.shortcodes = options.extension.shortcodes;
-    extension_options.wikilinks_title_after_pipe = options.extension.wikilinks_title_after_pipe;
-    extension_options.wikilinks_title_before_pipe = options.extension.wikilinks_title_before_pipe;
-    extension_options.underline = options.extension.underline;
-    extension_options.spoiler = options.extension.spoiler;
-    extension_options.greentext = options.extension.greentext;
-
-    extension_options
-}
-
-fn parse_options_from_ex_options(options: &ExOptions) -> ParseOptions {
-    let mut parse_options = ParseOptions::default();
-
-    parse_options.smart = options.parse.smart;
-    parse_options
-        .default_info_string
-        .clone_from(&options.parse.default_info_string);
-    parse_options.relaxed_tasklist_matching = options.parse.relaxed_tasklist_matching;
-    parse_options.relaxed_autolinks = options.parse.relaxed_autolinks;
-
-    parse_options
-}
-
-fn render_options_from_ex_options(options: &ExOptions) -> RenderOptions {
-    let mut render_options = RenderOptions::default();
-
-    render_options.hardbreaks = options.render.hardbreaks;
-    render_options.github_pre_lang = options.render.github_pre_lang;
-    render_options.full_info_string = options.render.full_info_string;
-    render_options.width = options.render.width;
-    render_options.unsafe_ = options.render.unsafe_;
-    render_options.escape = options.render.escape;
-    render_options.list_style = ListStyleType::from(options.render.list_style.clone());
-    render_options.sourcepos = options.render.sourcepos;
-    render_options.experimental_inline_sourcepos = options.render.experimental_inline_sourcepos;
-    render_options.escaped_char_spans = options.render.escaped_char_spans;
-    render_options.ignore_setext = options.render.ignore_setext;
-    render_options.ignore_empty_links = options.render.ignore_empty_links;
-    render_options.gfm_quirks = options.render.gfm_quirks;
-    render_options.prefer_fenced = options.render.prefer_fenced;
-
-    render_options
-}
-
-fn render(env: Env, unsafe_html: String, sanitize: bool) -> NifResult<Term> {
+fn maybe_sanitize(env: Env, unsafe_html: String, sanitize: bool) -> NifResult<Term> {
     let html = match sanitize {
         true => clean(&unsafe_html),
         false => unsafe_html,
     };
 
-    rustler::serde::to_term(env, html).map_err(|err| err.into())
+    Ok((ok(), html).encode(env))
+}
+
+#[rustler::nif(schedule = "DirtyCpu")]
+fn parse_document<'a>(env: Env<'a>, md: &str, options: ExOptions) -> NifResult<Term<'a>> {
+    let comrak_options = comrak::Options {
+        extension: extension_options_from_ex_options(&options),
+        parse: parse_options_from_ex_options(&options),
+        render: render_options_from_ex_options(&options),
+    };
+    let arena = Arena::new();
+    let root = comrak::parse_document(&arena, md, &comrak_options);
+    let ex_ast = to_elixir_ast(root);
+    Ok((ok(), vec![ex_ast]).encode(env))
+}
+
+#[rustler::nif(schedule = "DirtyCpu")]
+fn ast_to_html<'a>(env: Env<'a>, ast: Term<'a>) -> NifResult<Term<'a>> {
+    let ex_node = types::nodes::ExNode::decode(ast)?;
+
+    let arena = Arena::new();
+    let comrak_ast = ex_node_to_comrak_ast(&arena, &ex_node);
+
+    // FIXME: error handling format_html and from_utf8
+
+    let inkjet_adapter = InkjetAdapter::default();
+    let mut plugins = ComrakPlugins::default();
+    plugins.render.codefence_syntax_highlighter = Some(&inkjet_adapter);
+
+    let mut buffer = vec![];
+    comrak::format_html_with_plugins(comrak_ast, &Options::default(), &mut buffer, &plugins)
+        .unwrap();
+    let html = String::from_utf8(buffer).unwrap();
+
+    Ok((ok(), html).encode(env))
+}
+
+#[rustler::nif(schedule = "DirtyCpu")]
+fn ast_to_html_with_options<'a>(
+    env: Env<'a>,
+    ast: Term<'a>,
+    options: ExOptions,
+) -> NifResult<Term<'a>> {
+    let ex_node = types::nodes::ExNode::decode(ast)?;
+    let arena = Arena::new();
+    let comrak_ast = ex_node_to_comrak_ast(&arena, &ex_node);
+
+    let comrak_options = comrak::Options {
+        extension: extension_options_from_ex_options(&options),
+        parse: parse_options_from_ex_options(&options),
+        render: render_options_from_ex_options(&options),
+    };
+
+    match &options.features.syntax_highlight_theme {
+        Some(theme) => {
+            let inkjet_adapter = InkjetAdapter::new(
+                theme,
+                options
+                    .features
+                    .syntax_highlight_inline_style
+                    .unwrap_or(true),
+            );
+            let mut plugins = ComrakPlugins::default();
+            plugins.render.codefence_syntax_highlighter = Some(&inkjet_adapter);
+
+            let mut buffer = vec![];
+            comrak::format_html_with_plugins(comrak_ast, &comrak_options, &mut buffer, &plugins)
+                .unwrap();
+            let unsafe_html = String::from_utf8(buffer).unwrap();
+
+            maybe_sanitize(env, unsafe_html, options.features.sanitize)
+        }
+        None => {
+            let mut buffer = vec![];
+            comrak::format_html(comrak_ast, &comrak_options, &mut buffer).unwrap();
+            let unsafe_html = String::from_utf8(buffer).unwrap();
+
+            maybe_sanitize(env, unsafe_html, options.features.sanitize)
+        }
+    }
 }

--- a/native/comrak_nif/src/types.rs
+++ b/native/comrak_nif/src/types.rs
@@ -1,1 +1,17 @@
+pub mod nodes;
 pub mod options;
+
+pub mod atoms {
+    rustler::atoms! {
+        ok,
+        error,
+        invalid_structure,
+        empty,
+        missing_node_field,
+        missing_attr_field,
+        node_name_not_string,
+        unknown_node_name,
+        attr_key_not_string,
+        unknown_attr_value,
+    }
+}

--- a/native/comrak_nif/src/types/nodes.rs
+++ b/native/comrak_nif/src/types/nodes.rs
@@ -1,0 +1,113 @@
+use rustler::NifUntaggedEnum;
+use std::str::FromStr;
+
+#[derive(Debug, Clone, PartialEq, NifUntaggedEnum)]
+pub enum AttrValue {
+    U8(u8),
+    U32(u32),
+    Usize(usize),
+    Bool(bool),
+    Text(String),
+    List(Vec<String>),
+}
+
+#[derive(Debug, Clone)]
+pub enum NodeName {
+    Document,
+    FrontMatter,
+    BlockQuote,
+    List,
+    Item,
+    DescriptionList,
+    DescriptionItem,
+    DescriptionTerm,
+    DescriptionDetails,
+    CodeBlock,
+    HtmlBlock,
+    Paragraph,
+    Heading,
+    ThematicBreak,
+    FootnoteDefinition,
+    Table,
+    TableRow,
+    TableCell,
+    TaskItem,
+    SoftBreak,
+    LineBreak,
+    Code,
+    HtmlInline,
+    Emph,
+    Strong,
+    Strikethrough,
+    Superscript,
+    Link,
+    Image,
+    FootnoteReference,
+    ShortCode,
+    Math,
+    MultilineBlockQuote,
+    Escaped,
+    WikiLink,
+    Underline,
+    SpoileredText,
+    EscapedTag,
+}
+
+impl FromStr for NodeName {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "document" => Ok(NodeName::Document),
+            "front_matter" => Ok(NodeName::FrontMatter),
+            "block_quote" => Ok(NodeName::BlockQuote),
+            "list" => Ok(NodeName::List),
+            "item" => Ok(NodeName::Item),
+            "description_list" => Ok(NodeName::DescriptionList),
+            "description_item" => Ok(NodeName::DescriptionItem),
+            "description_term" => Ok(NodeName::DescriptionTerm),
+            "description_details" => Ok(NodeName::DescriptionDetails),
+            "code_block" => Ok(NodeName::CodeBlock),
+            "html_block" => Ok(NodeName::HtmlBlock),
+            "paragraph" => Ok(NodeName::Paragraph),
+            "heading" => Ok(NodeName::Heading),
+            "thematic_break" => Ok(NodeName::ThematicBreak),
+            "footnote_definition" => Ok(NodeName::FootnoteDefinition),
+            "table" => Ok(NodeName::Table),
+            "table_row" => Ok(NodeName::TableRow),
+            "table_cell" => Ok(NodeName::TableCell),
+            "task_item" => Ok(NodeName::TaskItem),
+            "soft_break" => Ok(NodeName::SoftBreak),
+            "line_break" => Ok(NodeName::LineBreak),
+            "code" => Ok(NodeName::Code),
+            "html_inline" => Ok(NodeName::HtmlInline),
+            "emph" => Ok(NodeName::Emph),
+            "strong" => Ok(NodeName::Strong),
+            "strikethrough" => Ok(NodeName::Strikethrough),
+            "superscript" => Ok(NodeName::Superscript),
+            "link" => Ok(NodeName::Link),
+            "image" => Ok(NodeName::Image),
+            "footnote_reference" => Ok(NodeName::FootnoteReference),
+            "short_code" => Ok(NodeName::ShortCode),
+            "math" => Ok(NodeName::Math),
+            "multiline_block_quote" => Ok(NodeName::MultilineBlockQuote),
+            "escaped" => Ok(NodeName::Escaped),
+            "wiki_link" => Ok(NodeName::WikiLink),
+            "underline" => Ok(NodeName::Underline),
+            "spoilered_text" => Ok(NodeName::SpoileredText),
+            "escaped_tag" => Ok(NodeName::EscapedTag),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum ExNode<'a> {
+    Element {
+        // name: &'a str,
+        name: NodeName,
+        attrs: Vec<(&'a str, AttrValue)>,
+        children: Vec<ExNode<'a>>,
+    },
+    Text(String),
+}

--- a/native/comrak_nif/src/types/options.rs
+++ b/native/comrak_nif/src/types/options.rs
@@ -1,4 +1,4 @@
-use comrak::ListStyleType;
+use comrak::{ExtensionOptions, ListStyleType, ParseOptions, RenderOptions};
 
 #[derive(Debug, NifStruct)]
 #[module = "MDEx.Types.ExtensionOptions"]
@@ -84,4 +84,68 @@ pub struct ExOptions {
     pub parse: ExParseOptions,
     pub render: ExRenderOptions,
     pub features: ExFeaturesOptions,
+}
+
+pub fn extension_options_from_ex_options(options: &ExOptions) -> ExtensionOptions {
+    let mut extension_options = ExtensionOptions::default();
+
+    extension_options.strikethrough = options.extension.strikethrough;
+    extension_options.tagfilter = options.extension.tagfilter;
+    extension_options.table = options.extension.table;
+    extension_options.autolink = options.extension.autolink;
+    extension_options.tasklist = options.extension.tasklist;
+    extension_options.superscript = options.extension.superscript;
+    extension_options
+        .header_ids
+        .clone_from(&options.extension.header_ids);
+    extension_options.footnotes = options.extension.footnotes;
+    extension_options.description_lists = options.extension.description_lists;
+    extension_options
+        .front_matter_delimiter
+        .clone_from(&options.extension.front_matter_delimiter);
+    extension_options.multiline_block_quotes = options.extension.multiline_block_quotes;
+    extension_options.math_dollars = options.extension.math_dollars;
+    extension_options.math_code = options.extension.math_code;
+    extension_options.shortcodes = options.extension.shortcodes;
+    extension_options.wikilinks_title_after_pipe = options.extension.wikilinks_title_after_pipe;
+    extension_options.wikilinks_title_before_pipe = options.extension.wikilinks_title_before_pipe;
+    extension_options.underline = options.extension.underline;
+    extension_options.spoiler = options.extension.spoiler;
+    extension_options.greentext = options.extension.greentext;
+
+    extension_options
+}
+
+pub fn parse_options_from_ex_options(options: &ExOptions) -> ParseOptions {
+    let mut parse_options = ParseOptions::default();
+
+    parse_options.smart = options.parse.smart;
+    parse_options
+        .default_info_string
+        .clone_from(&options.parse.default_info_string);
+    parse_options.relaxed_tasklist_matching = options.parse.relaxed_tasklist_matching;
+    parse_options.relaxed_autolinks = options.parse.relaxed_autolinks;
+
+    parse_options
+}
+
+pub fn render_options_from_ex_options(options: &ExOptions) -> RenderOptions {
+    let mut render_options = RenderOptions::default();
+
+    render_options.hardbreaks = options.render.hardbreaks;
+    render_options.github_pre_lang = options.render.github_pre_lang;
+    render_options.full_info_string = options.render.full_info_string;
+    render_options.width = options.render.width;
+    render_options.unsafe_ = options.render.unsafe_;
+    render_options.escape = options.render.escape;
+    render_options.list_style = ListStyleType::from(options.render.list_style.clone());
+    render_options.sourcepos = options.render.sourcepos;
+    render_options.experimental_inline_sourcepos = options.render.experimental_inline_sourcepos;
+    render_options.escaped_char_spans = options.render.escaped_char_spans;
+    render_options.ignore_setext = options.render.ignore_setext;
+    render_options.ignore_empty_links = options.render.ignore_empty_links;
+    render_options.gfm_quirks = options.render.gfm_quirks;
+    render_options.prefer_fenced = options.render.prefer_fenced;
+
+    render_options
 }

--- a/test/format_test.exs
+++ b/test/format_test.exs
@@ -1,0 +1,341 @@
+defmodule MDEx.FormatTest do
+  use ExUnit.Case
+
+  @extension [
+    strikethrough: true,
+    tagfilter: true,
+    table: true,
+    autolink: true,
+    tasklist: true,
+    superscript: true,
+    footnotes: true,
+    description_lists: true,
+    front_matter_delimiter: "---",
+    multiline_block_quotes: true,
+    math_dollars: true,
+    math_code: true,
+    shortcodes: true,
+    underline: true,
+    spoiler: true,
+    greentext: true
+  ]
+
+  def assert_format(document, expected, extension \\ []) do
+    opts = [
+      extension: Keyword.merge(@extension, extension),
+      render: [unsafe_: true]
+    ]
+
+    assert {:ok, ast} = MDEx.parse_document(document, opts)
+    assert {:ok, html} = MDEx.to_html(ast, opts)
+    # IO.puts(html)
+    assert html == expected
+  end
+
+  test "text" do
+    assert_format("mdex", "<p>mdex</p>\n")
+  end
+
+  test "front matter" do
+    assert_format(
+      """
+      ---
+      title: MDEx
+      ---
+      """,
+      ""
+    )
+  end
+
+  test "block quote" do
+    assert_format(
+      """
+      > MDEx
+      """,
+      "<blockquote>\n<p>MDEx</p>\n</blockquote>\n"
+    )
+  end
+
+  describe "list" do
+    test "unordered" do
+      assert_format(
+        """
+        - foo
+          - bar
+            - baz
+              - boo
+        """,
+        """
+        <ul>
+        <li>foo
+        <ul>
+        <li>bar
+        <ul>
+        <li>baz
+        <ul>
+        <li>boo</li>
+        </ul>
+        </li>
+        </ul>
+        </li>
+        </ul>
+        </li>
+        </ul>
+        """
+      )
+    end
+
+    test "ordered" do
+      assert_format(
+        """
+        1. foo
+        2.
+        3. bar
+        """,
+        """
+        <ol>
+        <li>foo</li>
+        <li></li>
+        <li>bar</li>
+        </ol>
+        """
+      )
+    end
+  end
+
+  test "description list" do
+    assert_format(
+      """
+      MDEx
+
+      : Built with Elixir and Rust
+      """,
+      """
+      <dl><dt>MDEx</dt>
+      <dd>
+      <p>Built with Elixir and Rust</p>
+      </dd>
+      </dl>
+      """
+    )
+  end
+
+  test "code block" do
+    assert_format(
+      """
+      ```elixir
+      String.trim(" MDEx ")
+      ```
+      """,
+      """
+      <pre class="autumn-hl" style="background-color: #282C34; color: #ABB2BF;"><code class="language-elixir" translate="no"><span class="ahl-namespace" style="color: #61AFEF;">String</span><span class="ahl-operator" style="color: #C678DD;">.</span><span class="ahl-function" style="color: #61AFEF;">trim</span><span class="ahl-punctuation ahl-bracket" style="color: #ABB2BF;">(</span><span class="ahl-string" style="color: #98C379;">&quot; MDEx &quot;</span><span class="ahl-punctuation ahl-bracket" style="color: #ABB2BF;">)</span>
+      </code></pre>
+      """
+    )
+  end
+
+  test "html block" do
+    assert_format(
+      """
+      <h1>MDEx</h1>
+      """,
+      "<h1>MDEx</h1>\n"
+    )
+  end
+
+  test "header" do
+    assert_format(
+      """
+      # level_1
+      ###### level_6
+      """,
+      """
+      <h1>level_1</h1>
+      <h6>level_6</h6>
+      """
+    )
+  end
+
+  test "footnote" do
+    assert_format(
+      """
+      footnote[^1]
+
+      [^1]: ref
+      """,
+      """
+      <p>footnote<sup class="footnote-ref"><a href="#fn-1" id="fnref-1" data-footnote-ref>1</a></sup></p>
+      <section class="footnotes" data-footnotes>
+      <ol>
+      <li id="fn-1">
+      <p>ref <a href="#fnref-1" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a></p>
+      </li>
+      </ol>
+      </section>
+      """
+    )
+  end
+
+  test "table" do
+    assert_format(
+      """
+      | foo | bar |
+      | --- | --- |
+      | baz | bim |
+      """,
+      """
+      <table>
+      <thead>
+      <tr>
+      <th>foo</th>
+      <th>bar</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr>
+      <td>baz</td>
+      <td>bim</td>
+      </tr>
+      </tbody>
+      </table>
+      """
+    )
+
+    assert_format(
+      """
+      | abc | defghi |
+      :-: | -----------:
+      bar | baz
+      """,
+      """
+      <table>
+      <thead>
+      <tr>
+      <th align="center">abc</th>
+      <th align="right">defghi</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr>
+      <td align="center">bar</td>
+      <td align="right">baz</td>
+      </tr>
+      </tbody>
+      </table>
+      """
+    )
+  end
+
+  test "task item" do
+    assert_format(
+      """
+      * [x] Done
+      * [ ] Not done
+      """,
+      """
+      <ul>
+      <li><input type="checkbox" checked="" disabled="" /> Done</li>
+      <li><input type="checkbox" disabled="" /> Not done</li>
+      </ul>
+      """
+    )
+  end
+
+  test "link" do
+    assert_format(
+      """
+      [foo]: /url "title"
+
+      [foo]
+      """,
+      """
+      <p><a href="/url" title="title">foo</a></p>
+      """
+    )
+  end
+
+  test "image" do
+    assert_format(
+      """
+      ![foo](/url "title")
+      """,
+      """
+      <p><img src="/url" alt="foo" title="title" /></p>
+      """
+    )
+  end
+
+  test "code" do
+    assert_format(
+      """
+      `String.trim(" MDEx ")`
+      """,
+      "<p><code>String.trim(&quot; MDEx &quot;)</code></p>\n"
+    )
+  end
+
+  test "shortcode" do
+    assert_format(
+      """
+      :smile:
+      """,
+      "<p>😄</p>\n"
+    )
+  end
+
+  test "math" do
+    assert_format(
+      """
+      $1 + 2$ and $$x = y$$
+
+      $`1 + 2`$
+      """,
+      """
+      <p><span data-math-style="inline">1 + 2</span> and <span data-math-style="display">x = y</span></p>
+      <p><code data-math-style="inline">1 + 2</code></p>
+      """
+    )
+  end
+
+  describe "wiki links" do
+    test "title before pipe" do
+      assert_format(
+        """
+        [[repo|https://github.com/leandrocp/mdex]]
+        """,
+        "<p><a href=\"https://github.com/leandrocp/mdex\" data-wikilink=\"true\">repo</a></p>\n",
+        wikilinks_title_before_pipe: true
+      )
+    end
+
+    test "title after pipe" do
+      assert_format(
+        """
+        [[https://github.com/leandrocp/mdex|repo]]
+        """,
+        "<p><a href=\"https://github.com/leandrocp/mdex\" data-wikilink=\"true\">repo</a></p>\n",
+        wikilinks_title_after_pipe: true
+      )
+    end
+  end
+
+  test "spoiler" do
+    assert_format(
+      """
+      Darth Vader is ||Luke's father||
+      """,
+      "<p>Darth Vader is <span class=\"spoiler\">Luke's father</span></p>\n"
+    )
+  end
+
+  test "greentext" do
+    assert_format(
+      """
+      > one
+      > > two
+      > three
+      """,
+      "<blockquote>\n<p>one</p>\n<blockquote>\n<p>two</p>\n</blockquote>\n<p>three</p>\n</blockquote>\n"
+    )
+  end
+end

--- a/test/parse_test.exs
+++ b/test/parse_test.exs
@@ -1,0 +1,491 @@
+defmodule MDEx.ParseTest do
+  use ExUnit.Case
+
+  @extension [
+    strikethrough: true,
+    tagfilter: true,
+    table: true,
+    autolink: true,
+    tasklist: true,
+    superscript: true,
+    footnotes: true,
+    description_lists: true,
+    front_matter_delimiter: "---",
+    multiline_block_quotes: true,
+    math_dollars: true,
+    math_code: true,
+    shortcodes: true,
+    underline: true,
+    spoiler: true,
+    greentext: true
+  ]
+
+  def assert_parse_document(document, expected, extension \\ []) do
+    opts = [
+      extension: Keyword.merge(@extension, extension)
+    ]
+
+    assert MDEx.parse_document(document, opts) == {:ok, expected}
+  end
+
+  test "text" do
+    assert_parse_document("mdex", [{"document", [], [{"paragraph", [], ["mdex"]}]}])
+  end
+
+  test "front matter" do
+    assert_parse_document(
+      """
+      ---
+      title: MDEx
+      ---
+      """,
+      [{"document", [], [{"front_matter", [{"content", "---\ntitle: MDEx\n---\n"}], []}]}]
+    )
+  end
+
+  test "block quote" do
+    assert_parse_document(
+      """
+      > MDEx
+      """,
+      [{"document", [], [{"block_quote", [], [{"paragraph", [], ["MDEx"]}]}]}]
+    )
+  end
+
+  describe "list" do
+    test "unordered" do
+      assert_parse_document(
+        """
+        - foo
+          - bar
+            - baz
+              - boo
+        """,
+        [
+          {"document", [],
+           [
+             {"list",
+              [
+                {"list_type", "bullet"},
+                {"marker_offset", 0},
+                {"padding", 2},
+                {"start", 1},
+                {"delimiter", "period"},
+                {"bullet_char", "-"},
+                {"tight", true}
+              ],
+              [
+                {"item",
+                 [
+                   {"list_type", "bullet"},
+                   {"marker_offset", 0},
+                   {"padding", 2},
+                   {"start", 1},
+                   {"delimiter", "period"},
+                   {"bullet_char", "-"},
+                   {"tight", false}
+                 ],
+                 [
+                   {"paragraph", [], ["foo"]},
+                   {"list",
+                    [
+                      {"list_type", "bullet"},
+                      {"marker_offset", 0},
+                      {"padding", 2},
+                      {"start", 1},
+                      {"delimiter", "period"},
+                      {"bullet_char", "-"},
+                      {"tight", true}
+                    ],
+                    [
+                      {"item",
+                       [
+                         {"list_type", "bullet"},
+                         {"marker_offset", 0},
+                         {"padding", 2},
+                         {"start", 1},
+                         {"delimiter", "period"},
+                         {"bullet_char", "-"},
+                         {"tight", false}
+                       ],
+                       [
+                         {"paragraph", [], ["bar"]},
+                         {"list",
+                          [
+                            {"list_type", "bullet"},
+                            {"marker_offset", 0},
+                            {"padding", 2},
+                            {"start", 1},
+                            {"delimiter", "period"},
+                            {"bullet_char", "-"},
+                            {"tight", true}
+                          ],
+                          [
+                            {"item",
+                             [
+                               {"list_type", "bullet"},
+                               {"marker_offset", 0},
+                               {"padding", 2},
+                               {"start", 1},
+                               {"delimiter", "period"},
+                               {"bullet_char", "-"},
+                               {"tight", false}
+                             ],
+                             [
+                               {"paragraph", [], ["baz"]},
+                               {"list",
+                                [
+                                  {"list_type", "bullet"},
+                                  {"marker_offset", 0},
+                                  {"padding", 2},
+                                  {"start", 1},
+                                  {"delimiter", "period"},
+                                  {"bullet_char", "-"},
+                                  {"tight", true}
+                                ],
+                                [
+                                  {"item",
+                                   [
+                                     {"list_type", "bullet"},
+                                     {"marker_offset", 0},
+                                     {"padding", 2},
+                                     {"start", 1},
+                                     {"delimiter", "period"},
+                                     {"bullet_char", "-"},
+                                     {"tight", false}
+                                   ], [{"paragraph", [], ["boo"]}]}
+                                ]}
+                             ]}
+                          ]}
+                       ]}
+                    ]}
+                 ]}
+              ]}
+           ]}
+        ]
+      )
+    end
+
+    test "ordered" do
+      assert_parse_document(
+        """
+        1. foo
+        2.
+        3. bar
+        """,
+        [
+          {"document", [],
+           [
+             {"list",
+              [
+                {"list_type", "ordered"},
+                {"marker_offset", 0},
+                {"padding", 3},
+                {"start", 1},
+                {"delimiter", "period"},
+                {"bullet_char", ""},
+                {"tight", true}
+              ],
+              [
+                {"item",
+                 [
+                   {"list_type", "ordered"},
+                   {"marker_offset", 0},
+                   {"padding", 3},
+                   {"start", 1},
+                   {"delimiter", "period"},
+                   {"bullet_char", ""},
+                   {"tight", false}
+                 ], [{"paragraph", [], ["foo"]}]},
+                {"item",
+                 [
+                   {"list_type", "ordered"},
+                   {"marker_offset", 0},
+                   {"padding", 3},
+                   {"start", 2},
+                   {"delimiter", "period"},
+                   {"bullet_char", ""},
+                   {"tight", false}
+                 ], []},
+                {"item",
+                 [
+                   {"list_type", "ordered"},
+                   {"marker_offset", 0},
+                   {"padding", 3},
+                   {"start", 3},
+                   {"delimiter", "period"},
+                   {"bullet_char", ""},
+                   {"tight", false}
+                 ], [{"paragraph", [], ["bar"]}]}
+              ]}
+           ]}
+        ]
+      )
+    end
+  end
+
+  test "description list" do
+    assert_parse_document(
+      """
+      MDEx
+
+      : Built with Elixir and Rust
+      """,
+      [
+        {"document", [],
+         [
+           {"description_list", [],
+            [
+              {"description_item", [{"marker_offset", 0}, {"padding", 2}],
+               [
+                 {"description_term", [], [{"paragraph", [], ["MDEx"]}]},
+                 {"description_details", [], [{"paragraph", [], ["Built with Elixir and Rust"]}]}
+               ]}
+            ]}
+         ]}
+      ]
+    )
+  end
+
+  test "code block" do
+    assert_parse_document(
+      """
+      ```elixir
+      String.trim(" MDEx ")
+      ```
+      """,
+      [
+        {"document", [],
+         [
+           {"code_block",
+            [
+              {"fenced", true},
+              {"fence_char", "`"},
+              {"fence_length", 3},
+              {"fence_offset", 0},
+              {"info", "elixir"},
+              {"literal", "String.trim(\" MDEx \")\n"}
+            ], []}
+         ]}
+      ]
+    )
+  end
+
+  test "html block" do
+    assert_parse_document(
+      """
+      <h1>MDEx</h1>
+      """,
+      [
+        {"document", [],
+         [
+           {"html_block", [{"block_type", 6}, {"literal", "<h1>MDEx</h1>\n"}], []}
+         ]}
+      ]
+    )
+  end
+
+  test "header" do
+    assert_parse_document(
+      """
+      # level_1
+      ###### level_6
+      """,
+      [
+        {"document", [],
+         [
+           {"heading", [{"level", 1}, {"setext", false}], ["level_1"]},
+           {"heading", [{"level", 6}, {"setext", false}], ["level_6"]}
+         ]}
+      ]
+    )
+  end
+
+  test "footnote" do
+    assert_parse_document(
+      """
+      footnote[^1]
+
+      [^1]: ref
+      """,
+      [
+        {"document", [],
+         [
+           {"paragraph", [], ["footnote", {"footnote_reference", [{"name", "1"}, {"ref_num", 1}, {"ix", 1}], []}]},
+           {"footnote_definition", [{"name", "1"}, {"total_references", 1}], [{"paragraph", [], ["ref"]}]}
+         ]}
+      ]
+    )
+  end
+
+  test "table" do
+    assert_parse_document(
+      """
+      | foo | bar |
+      | --- | --- |
+      | baz | bim |
+      """,
+      [
+        {"document", [],
+         [
+           {"table", [{"alignments", ["none", "none"]}, {"num_columns", 2}, {"num_rows", 1}, {"num_nonempty_cells", 2}],
+            [
+              {"table_row", [{"header", true}], [{"table_cell", [], ["foo"]}, {"table_cell", [], ["bar"]}]},
+              {"table_row", [{"header", false}], [{"table_cell", [], ["baz"]}, {"table_cell", [], ["bim"]}]}
+            ]}
+         ]}
+      ]
+    )
+
+    assert_parse_document(
+      """
+      | abc | defghi |
+      :-: | -----------:
+      bar | baz
+      """,
+      [
+        {"document", [],
+         [
+           {"table", [{"alignments", ["center", "right"]}, {"num_columns", 2}, {"num_rows", 1}, {"num_nonempty_cells", 2}],
+            [
+              {"table_row", [{"header", true}], [{"table_cell", [], ["abc"]}, {"table_cell", [], ["defghi"]}]},
+              {"table_row", [{"header", false}], [{"table_cell", [], ["bar"]}, {"table_cell", [], ["baz"]}]}
+            ]}
+         ]}
+      ]
+    )
+  end
+
+  test "task item" do
+    assert_parse_document(
+      """
+      * [x] Done
+      * [ ] Not done
+      """,
+      [
+        {"document", [],
+         [
+           {"list",
+            [
+              {"list_type", "bullet"},
+              {"marker_offset", 0},
+              {"padding", 2},
+              {"start", 1},
+              {"delimiter", "period"},
+              {"bullet_char", "*"},
+              {"tight", true}
+            ],
+            [
+              {"task_item", [{"checked", true}, {"symbol", "x"}], [{"paragraph", [], ["Done"]}]},
+              {"task_item", [{"checked", false}], [{"paragraph", [], ["Not done"]}]}
+            ]}
+         ]}
+      ]
+    )
+  end
+
+  test "link" do
+    assert_parse_document(
+      """
+      [foo]: /url "title"
+
+      [foo]
+      """,
+      [{"document", [], [{"paragraph", [], [{"link", [{"url", "/url"}, {"title", "title"}], ["foo"]}]}]}]
+    )
+  end
+
+  test "image" do
+    assert_parse_document(
+      """
+      ![foo](/url "title")
+      """,
+      [{"document", [], [{"paragraph", [], [{"image", [{"url", "/url"}, {"title", "title"}], ["foo"]}]}]}]
+    )
+  end
+
+  test "code" do
+    assert_parse_document(
+      """
+      `String.trim(" MDEx ")`
+      """,
+      [{"document", [], [{"paragraph", [], [{"code", [{"num_backticks", 1}, {"literal", "String.trim(\" MDEx \")"}], []}]}]}]
+    )
+  end
+
+  test "shortcode" do
+    assert_parse_document(
+      """
+      :smile:
+      """,
+      [{"document", [], [{"paragraph", [], [{"short_code", [{"code", "smile"}, {"emoji", "😄"}], []}]}]}]
+    )
+  end
+
+  test "math" do
+    assert_parse_document(
+      """
+      $1 + 2$ and $$x = y$$
+
+      $`1 + 2`$
+      """,
+      [
+        {"document", [],
+         [
+           {"paragraph", [],
+            [
+              {"math", [{"dollar_math", true}, {"display_math", false}, {"literal", "1 + 2"}], []},
+              " and ",
+              {"math", [{"dollar_math", true}, {"display_math", true}, {"literal", "x = y"}], []}
+            ]},
+           {"paragraph", [], [{"math", [{"dollar_math", false}, {"display_math", false}, {"literal", "1 + 2"}], []}]}
+         ]}
+      ]
+    )
+  end
+
+  describe "wiki links" do
+    test "title before pipe" do
+      assert_parse_document(
+        """
+        [[repo|https://github.com/leandrocp/mdex]]
+        """,
+        [{"document", [], [{"paragraph", [], [{"wiki_link", [{"url", "https://github.com/leandrocp/mdex"}], ["repo"]}]}]}],
+        wikilinks_title_before_pipe: true
+      )
+    end
+
+    test "title after pipe" do
+      assert_parse_document(
+        """
+        [[https://github.com/leandrocp/mdex|repo]]
+        """,
+        [{"document", [], [{"paragraph", [], [{"wiki_link", [{"url", "https://github.com/leandrocp/mdex"}], ["repo"]}]}]}],
+        wikilinks_title_after_pipe: true
+      )
+    end
+  end
+
+  test "spoiler" do
+    assert_parse_document(
+      """
+      Darth Vader is ||Luke's father||
+      """,
+      [{"document", [], [{"paragraph", [], ["Darth Vader is ", {"spoilered_text", [], ["Luke's father"]}]}]}]
+    )
+  end
+
+  test "greentext" do
+    assert_parse_document(
+      """
+      > one
+      > > two
+      > three
+      """,
+      [
+        {"document", [],
+         [{"block_quote", [], [{"paragraph", [], ["one"]}, {"block_quote", [], [{"paragraph", [], ["two"]}]}, {"paragraph", [], ["three"]}]}]}
+      ]
+    )
+  end
+end


### PR DESCRIPTION
With this code is now possible to convert markdown to an AST data structure to inspect and manipulate using regular Elixir APIs based on Floki since we're using the exact same format as `{node, attrs, children}`.

Two examples are available to show how that works:

### Mermaid

https://github.com/leandrocp/mdex/blob/lp-encode-decode-ast/examples/mermaid.exs

<img width="830" alt="mermaid" src="https://github.com/user-attachments/assets/82c17e9d-c106-48a5-be44-56efb093a7c0">

### Alerts

https://github.com/leandrocp/mdex/blob/lp-encode-decode-ast/examples/alerts.exs

<img width="1296" alt="alerts" src="https://github.com/user-attachments/assets/04d7176c-d31c-401c-8f21-2f2af547888f">

------------------

Those functions are pretty low-level at the moment but we'll provide a more high-level API to manipulate the AST and also to attach plugins.
