### PR TITLE
Add Elixir functions to expose native to_commonmark & to_commonmark_with_options

### DIFF
--- a/lib/mdex/native.ex
+++ b/lib/mdex/native.ex
@@ -58,4 +58,6 @@ defmodule MDEx.Native do
   def parse_document(_md, _options), do: :erlang.nif_error(:nif_not_loaded)
   def ast_to_html(_ast), do: :erlang.nif_error(:nif_not_loaded)
   def ast_to_html_with_options(_ast, _options), do: :erlang.nif_error(:nif_not_loaded)
+  def ast_to_commonmark(_ast), do: :erlang.nif_error(:nif_not_loaded)
+  def ast_to_commonmark_with_options(_ast, _options), do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/native/comrak_nif/src/lib.rs
+++ b/native/comrak_nif/src/lib.rs
@@ -24,7 +24,9 @@ rustler::init!(
         markdown_to_html,
         markdown_to_html_with_options,
         ast_to_html,
-        ast_to_html_with_options
+        ast_to_html_with_options,
+        ast_to_commonmark,
+        ast_to_commonmark_with_options
     ]
 );
 
@@ -151,6 +153,77 @@ fn ast_to_html_with_options<'a>(
         None => {
             let mut buffer = vec![];
             comrak::format_html(comrak_ast, &comrak_options, &mut buffer).unwrap();
+            let unsafe_html = String::from_utf8(buffer).unwrap();
+
+            maybe_sanitize(env, unsafe_html, options.features.sanitize)
+        }
+    }
+}
+
+#[rustler::nif(schedule = "DirtyCpu")]
+fn ast_to_commonmark<'a>(env: Env<'a>, ast: Term<'a>) -> NifResult<Term<'a>> {
+    let ex_node = types::nodes::ExNode::decode(ast)?;
+
+    let arena = Arena::new();
+    let comrak_ast = ex_node_to_comrak_ast(&arena, &ex_node);
+
+    // FIXME: error handling format_html and from_utf8
+
+    let inkjet_adapter = InkjetAdapter::default();
+    let mut plugins = ComrakPlugins::default();
+    plugins.render.codefence_syntax_highlighter = Some(&inkjet_adapter);
+
+    let mut buffer = vec![];
+    comrak::format_commonmark_with_plugins(comrak_ast, &Options::default(), &mut buffer, &plugins)
+        .unwrap();
+    let html = String::from_utf8(buffer).unwrap();
+
+    Ok((ok(), html).encode(env))
+}
+
+#[rustler::nif(schedule = "DirtyCpu")]
+fn ast_to_commonmark_with_options<'a>(
+    env: Env<'a>,
+    ast: Term<'a>,
+    options: ExOptions,
+) -> NifResult<Term<'a>> {
+    let ex_node = types::nodes::ExNode::decode(ast)?;
+    let arena = Arena::new();
+    let comrak_ast = ex_node_to_comrak_ast(&arena, &ex_node);
+
+    let comrak_options = comrak::Options {
+        extension: extension_options_from_ex_options(&options),
+        parse: parse_options_from_ex_options(&options),
+        render: render_options_from_ex_options(&options),
+    };
+
+    match &options.features.syntax_highlight_theme {
+        Some(theme) => {
+            let inkjet_adapter = InkjetAdapter::new(
+                theme,
+                options
+                    .features
+                    .syntax_highlight_inline_style
+                    .unwrap_or(true),
+            );
+            let mut plugins = ComrakPlugins::default();
+            plugins.render.codefence_syntax_highlighter = Some(&inkjet_adapter);
+
+            let mut buffer = vec![];
+            comrak::format_commonmark_with_plugins(
+                comrak_ast,
+                &comrak_options,
+                &mut buffer,
+                &plugins,
+            )
+            .unwrap();
+            let unsafe_html = String::from_utf8(buffer).unwrap();
+
+            maybe_sanitize(env, unsafe_html, options.features.sanitize)
+        }
+        None => {
+            let mut buffer = vec![];
+            comrak::format_commonmark(comrak_ast, &comrak_options, &mut buffer).unwrap();
             let unsafe_html = String::from_utf8(buffer).unwrap();
 
             maybe_sanitize(env, unsafe_html, options.features.sanitize)

--- a/test/format_test.exs
+++ b/test/format_test.exs
@@ -20,6 +20,18 @@ defmodule MDEx.FormatTest do
     greentext: true
   ]
 
+  def assert_commonmark(document, extension \\ []) do
+    opts = [
+      extension: Keyword.merge(@extension, extension),
+      render: [unsafe_: true]
+    ]
+
+    assert {:ok, ast} = MDEx.parse_document(document, opts)
+    assert {:ok, markdown} = MDEx.to_commonmark(ast, opts)
+
+    assert markdown == document
+  end
+
   def assert_format(document, expected, extension \\ []) do
     opts = [
       extension: Keyword.merge(@extension, extension),
@@ -28,12 +40,21 @@ defmodule MDEx.FormatTest do
 
     assert {:ok, ast} = MDEx.parse_document(document, opts)
     assert {:ok, html} = MDEx.to_html(ast, opts)
+
     # IO.puts(html)
     assert html == expected
   end
 
   test "text" do
     assert_format("mdex", "<p>mdex</p>\n")
+
+    assert_commonmark("""
+    mdex
+    """)
+
+    assert_commonmark("""
+    Hello ~world~ there
+    """)
   end
 
   test "front matter" do
@@ -54,6 +75,10 @@ defmodule MDEx.FormatTest do
       """,
       "<blockquote>\n<p>MDEx</p>\n</blockquote>\n"
     )
+
+    assert_commonmark("""
+    > MDEx
+    """)
   end
 
   describe "list" do


### PR DESCRIPTION
I have a use case where I’d like to parse a document, modify the AST, then render it back to markdown.  This PR exposes the native to_commonmark & to_commonmark_with_options functionality on the Elixir side.

I included a couple of tests and could reuse more of the existing tests, but many of the existing examples show minor differences when rendered back to Markdown, mostly whitespace, trailing newlines, etc.  