### PR TITLE
fix misspelling of "thematic" causing render errors

### DIFF
--- a/native/comrak_nif/src/encoder.rs
+++ b/native/comrak_nif/src/encoder.rs
@@ -20,7 +20,7 @@ impl Encoder for NodeName {
             Self::HtmlBlock => "html_block",
             Self::Paragraph => "paragraph",
             Self::Heading => "heading",
-            Self::ThematicBreak => "themantic_break",
+            Self::ThematicBreak => "thematic_break",
             Self::FootnoteDefinition => "footnote_definition",
             Self::Table => "table",
             Self::TableRow => "table_row",

--- a/test/format_test.exs
+++ b/test/format_test.exs
@@ -68,6 +68,17 @@ defmodule MDEx.FormatTest do
     )
   end
 
+  test "thematic break" do
+    assert_format(
+      """
+      ---
+      # Heading
+
+      """,
+      "<hr />\n<h1>Heading</h1>\n"
+    )
+  end
+
   test "block quote" do
     assert_format(
       """


### PR DESCRIPTION
Currently in master:

```
iex(9)> MDEx.parse_document!("---\nTest") |> MDEx.to_html
{:error,
 {:unknown_node_name, "themantic_break", "(<<\"themantic_break\">>, [], [])"}}
```

The markdown `---` corresponds to a "thematic break" which should produce a `<hr/>` HTML tag, but a typo ("themantic") in the name causes an error when rendering the content.

This PR fixes the name and adds a test.