### PR TITLE
Add support for `<figure>` with caption

### DIFF
--- a/lib/mdex/types/options.ex
+++ b/lib/mdex/types/options.ex
@@ -44,7 +44,8 @@ defmodule MDEx.Types.RenderOptions do
             ignore_setext: false,
             ignore_empty_links: false,
             gfm_quirks: false,
-            prefer_fenced: false
+            prefer_fenced: false,
+            figure_with_caption: false
 end
 
 defmodule MDEx.Types.FeaturesOptions do

--- a/native/comrak_nif/Cargo.lock
+++ b/native/comrak_nif/Cargo.lock
@@ -221,9 +221,9 @@ checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "comrak"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ab67843c57df5a4ee29d610740828dbc928cc64ecf0f2a1d5cd0e98e107a9"
+checksum = "d8c32ff8b21372fab0e9ecc4e42536055702dc5faa418362bffd1544f9d12637"
 dependencies = [
  "caseless",
  "clap",

--- a/native/comrak_nif/Cargo.toml
+++ b/native/comrak_nif/Cargo.toml
@@ -16,7 +16,7 @@ rustler = { version = "0.33", features = [
     "serde",
 ] }
 serde = "1.0"
-comrak = { version = "0.26", features = ["shortcodes"] }
+comrak = { version = "0.29", features = ["shortcodes"] }
 ammonia = "4.0"
 phf = { version = "0.11", features = ["macros"] }
 tree-sitter = "0.20"

--- a/native/comrak_nif/src/types/options.rs
+++ b/native/comrak_nif/src/types/options.rs
@@ -67,6 +67,7 @@ pub struct ExRenderOptions {
     pub ignore_empty_links: bool,
     pub gfm_quirks: bool,
     pub prefer_fenced: bool,
+    pub figure_with_caption: bool,
 }
 
 #[derive(Debug, NifStruct)]
@@ -146,6 +147,7 @@ pub fn render_options_from_ex_options(options: &ExOptions) -> RenderOptions {
     render_options.ignore_empty_links = options.render.ignore_empty_links;
     render_options.gfm_quirks = options.render.gfm_quirks;
     render_options.prefer_fenced = options.render.prefer_fenced;
+    render_options.figure_with_caption = options.render.figure_with_caption;
 
     render_options
 }


### PR DESCRIPTION
Close https://github.com/leandrocp/mdex/issues/82

```
iex> MDEx.to_html!("![image](https://example.com/image.png \"this is an image\")", render: [figure_with_caption: true])
"<p><figure><img src=\"https://example.com/image.png\" alt=\"image\" title=\"this is an image\" /><figcaption>this is an image</figcaption></figure></p>\n"
```