### PR TITLE
sanitize: add custom options.

### DIFF
--- a/lib/mdex.ex
+++ b/lib/mdex.ex
@@ -651,7 +651,7 @@ defmodule MDEx do
     - `:sanitize` - cleans HTML after rendering. Defaults to `:clean`.
         - `:clean` or `true` - uses these rules: https://docs.rs/ammonia/latest/ammonia/fn.clean.html
         - `nil` or `false` - do no sanitization.
-        - `[allowed_classes: %{"span" => "hidden"}, ...]` - use custom options. (TODO: elaborate)
+        - `[allowed_classes: %{set: %{"span" => "hidden"}}, ...]` - set custom options.
     - `:escape` - which entities should be escaped. Defaults to `[:content, :curly_braces_in_code]`.
         - `:content` - escape common chars like `<`, `>`, `&`, and others in the HTML content;
         - `:curly_braces_in_code` - escape `{` and `}` only inside `<code>` tags, particularly useful for compiling HTML in LiveView;

--- a/lib/mdex.ex
+++ b/lib/mdex.ex
@@ -649,7 +649,7 @@ defmodule MDEx do
   ## Options
 
     - `:sanitize` - cleans HTML after rendering. Defaults to `:clean`.
-        - `:clean` or `true` - uses these rules: https://docs.rs/ammonia/latest/ammonia/fn.clean.html.
+        - `:clean` or `true` - uses these rules: https://docs.rs/ammonia/latest/ammonia/fn.clean.html
         - `nil` or `false` - do no sanitization.
         - `[allowed_classes: %{"span" => "hidden"}, ...]` - use custom options. (TODO: elaborate)
     - `:escape` - which entities should be escaped. Defaults to `[:content, :curly_braces_in_code]`.

--- a/lib/mdex.ex
+++ b/lib/mdex.ex
@@ -596,9 +596,38 @@ defmodule MDEx do
       extension: struct(MDEx.Types.ExtensionOptions, extension),
       parse: struct(MDEx.Types.ParseOptions, parse),
       render: struct(MDEx.Types.RenderOptions, render),
-      features: struct(MDEx.Types.FeaturesOptions, features)
+      features: struct(MDEx.Types.FeaturesOptions, features) |> adapt_sanitize_option()
     }
   end
+
+  defp adapt_sanitize_option(%MDEx.Types.FeaturesOptions{} = features),
+    do: update_in(features.sanitize, &adapt_sanitize_option/1)
+
+  defp adapt_sanitize_option(false), do: nil
+  defp adapt_sanitize_option(true), do: :clean
+  defp adapt_sanitize_option(opt) when opt in [nil, :clean], do: opt
+
+  @set_add_rm_attrs [
+    :tags,
+    :clean_content_tags,
+    :tag_attributes,
+    :tag_attribute_values,
+    :generic_attribute_prefixes,
+    :generic_attributes,
+    :url_schemes,
+    :allowed_classes,
+    :set_tag_attribute_values
+  ]
+  defp adapt_sanitize_option(sanitize) do
+    sanitize =
+      for attr <- @set_add_rm_attrs, reduce: struct(MDEx.Types.SanitizeCustom, sanitize) do
+        sanitize -> update_in(sanitize, [Access.key!(attr)], &adapt_sanitize_set_add_rm/1)
+      end
+
+    {:custom, sanitize}
+  end
+
+  defp adapt_sanitize_set_add_rm(value), do: struct(MDEx.Types.SanitizeCustomSetAddRm, value)
 
   defp maybe_trim({:ok, result}), do: {:ok, String.trim(result)}
   defp maybe_trim(error), do: error
@@ -619,13 +648,16 @@ defmodule MDEx do
 
   ## Options
 
-    - `:sanitize` - clean HTML using these rules https://docs.rs/ammonia/latest/ammonia/fn.clean.html. Defaults to `true`.
+    - `:sanitize` - cleans HTML after rendering. Defaults to `:clean`.
+        - `:clean` or `true` - uses these rules: https://docs.rs/ammonia/latest/ammonia/fn.clean.html.
+        - `nil` or `false` - do no sanitization.
+        - `[allowed_classes: %{"span" => "hidden"}, ...]` - use custom options. (TODO: elaborate)
     - `:escape` - which entities should be escaped. Defaults to `[:content, :curly_braces_in_code]`.
         - `:content` - escape common chars like `<`, `>`, `&`, and others in the HTML content;
         - `:curly_braces_in_code` - escape `{` and `}` only inside `<code>` tags, particularly useful for compiling HTML in LiveView;
   """
   def safe_html(unsafe_html, opts \\ []) when is_binary(unsafe_html) and is_list(opts) do
-    sanitize = opt(opts, [:sanitize], true)
+    sanitize = opt(opts, [:sanitize], :clean) |> adapt_sanitize_option()
     escape_content = opt(opts, [:escape, :content], true)
     escape_curly_braces_in_code = opt(opts, [:escape, :curly_braces_in_code], true)
     Native.safe_html(unsafe_html, sanitize, escape_content, escape_curly_braces_in_code)

--- a/lib/mdex/types/options.ex
+++ b/lib/mdex/types/options.ex
@@ -55,9 +55,34 @@ end
 
 defmodule MDEx.Types.FeaturesOptions do
   @moduledoc false
-  defstruct sanitize: false,
+  defstruct sanitize: nil,
             syntax_highlight_theme: "onedark",
             syntax_highlight_inline_style: true
+end
+
+defmodule MDEx.Types.SanitizeCustomSetAddRm do
+  @moduledoc false
+  defstruct set: nil,
+            add: nil,
+            rm: nil
+end
+
+defmodule MDEx.Types.SanitizeCustom do
+  @moduledoc false
+  defstruct base: :default,
+            tags: [],
+            clean_content_tags: [],
+            tag_attributes: [],
+            tag_attribute_values: [],
+            generic_attribute_prefixes: [],
+            generic_attributes: [],
+            url_schemes: [],
+            allowed_classes: [],
+            set_tag_attribute_values: [],
+            strip_comments: nil,
+            link_rel: :unset,
+            id_prefix: :unset,
+            url_relative: nil
 end
 
 defmodule MDEx.Types.Options do

--- a/lib/mdex/types/options.ex
+++ b/lib/mdex/types/options.ex
@@ -80,8 +80,8 @@ defmodule MDEx.Types.SanitizeCustom do
             allowed_classes: [],
             set_tag_attribute_values: [],
             strip_comments: nil,
-            link_rel: :unset,
-            id_prefix: :unset,
+            link_rel: "noopener noreferrer",
+            id_prefix: nil,
             url_relative: nil
 end
 

--- a/native/comrak_nif/src/lib.rs
+++ b/native/comrak_nif/src/lib.rs
@@ -37,7 +37,7 @@ fn markdown_to_html<'a>(env: Env<'a>, md: &str) -> NifResult<Term<'a>> {
     let unsafe_html = comrak::markdown_to_html_with_plugins(md, &Options::default(), &plugins);
     let html = do_safe_html(
         unsafe_html,
-        ExFeaturesOptions::default().sanitize,
+        &ExFeaturesOptions::default().sanitize,
         false,
         true,
     );
@@ -67,12 +67,12 @@ fn markdown_to_html_with_options<'a>(
             let mut plugins = ComrakPlugins::default();
             plugins.render.codefence_syntax_highlighter = Some(&inkjet_adapter);
             let unsafe_html = comrak::markdown_to_html_with_plugins(md, &comrak_options, &plugins);
-            let html = do_safe_html(unsafe_html, options.features.sanitize, false, true);
+            let html = do_safe_html(unsafe_html, &options.features.sanitize, false, true);
             Ok((ok(), html).encode(env))
         }
         None => {
             let unsafe_html = comrak::markdown_to_html(md, &comrak_options);
-            let html = do_safe_html(unsafe_html, options.features.sanitize, false, true);
+            let html = do_safe_html(unsafe_html, &options.features.sanitize, false, true);
             Ok((ok(), html).encode(env))
         }
     }
@@ -218,7 +218,7 @@ fn document_to_html(env: Env<'_>, ex_document: ExDocument) -> NifResult<Term<'_>
     let unsafe_html = String::from_utf8(buffer).unwrap();
     let html = do_safe_html(
         unsafe_html,
-        ExFeaturesOptions::default().sanitize,
+        &ExFeaturesOptions::default().sanitize,
         false,
         true,
     );
@@ -257,14 +257,14 @@ fn document_to_html_with_options(
             comrak::format_html_with_plugins(comrak_ast, &comrak_options, &mut buffer, &plugins)
                 .unwrap();
             let unsafe_html = String::from_utf8(buffer).unwrap();
-            let html = do_safe_html(unsafe_html, options.features.sanitize, false, true);
+            let html = do_safe_html(unsafe_html, &options.features.sanitize, false, true);
             Ok((ok(), html).encode(env))
         }
         None => {
             let mut buffer = vec![];
             comrak::format_commonmark(comrak_ast, &comrak_options, &mut buffer).unwrap();
             let unsafe_html = String::from_utf8(buffer).unwrap();
-            let html = do_safe_html(unsafe_html, options.features.sanitize, false, true);
+            let html = do_safe_html(unsafe_html, &options.features.sanitize, false, true);
             Ok((ok(), html).encode(env))
         }
     }
@@ -340,13 +340,13 @@ fn document_to_xml_with_options(
 pub fn safe_html(
     env: Env<'_>,
     unsafe_html: String,
-    sanitize: bool,
+    sanitize: Option<ExSanitizeOption>,
     escape_content: bool,
     escape_curly_braces_in_code: bool,
 ) -> NifResult<Term<'_>> {
     Ok(do_safe_html(
         unsafe_html,
-        sanitize,
+        &sanitize,
         escape_content,
         escape_curly_braces_in_code,
     )
@@ -356,13 +356,13 @@ pub fn safe_html(
 // https://github.com/p-jackson/entities/blob/1d166204433c2ee7931251a5494f94c7e35be9d6/src/entities.rs
 fn do_safe_html(
     unsafe_html: String,
-    sanitize: bool,
+    sanitize: &Option<ExSanitizeOption>,
     escape_content: bool,
     escape_curly_braces_in_code: bool,
 ) -> String {
     let html = match sanitize {
-        true => ammonia::clean(&unsafe_html),
-        false => unsafe_html,
+        None => unsafe_html,
+        Some(sanitize_option) => sanitize_option.clean(&unsafe_html),
     };
 
     let html = match escape_curly_braces_in_code {

--- a/native/comrak_nif/src/types/options.rs
+++ b/native/comrak_nif/src/types/options.rs
@@ -1,3 +1,7 @@
+mod sanitize;
+
+pub use sanitize::*;
+
 use comrak::{ExtensionOptions, ListStyleType, ParseOptions, RenderOptions};
 
 #[derive(Debug, NifStruct)]
@@ -75,10 +79,27 @@ pub struct ExRenderOptions {
     pub experimental_minimize_commonmark: bool,
 }
 
+#[derive(Debug, NifTaggedEnum, Default)]
+pub enum ExSanitizeOption {
+    #[default]
+    Clean,
+
+    Custom(Box<ExSanitizeCustom>),
+}
+
+impl ExSanitizeOption {
+    pub(crate) fn clean(&self, html: &str) -> String {
+        match self {
+            ExSanitizeOption::Clean => ammonia::clean(html),
+            ExSanitizeOption::Custom(custom) => custom.to_ammonia().clean(html).to_string(),
+        }
+    }
+}
+
 #[derive(Debug, NifStruct, Default)]
 #[module = "MDEx.Types.FeaturesOptions"]
 pub struct ExFeaturesOptions {
-    pub sanitize: bool,
+    pub sanitize: Option<ExSanitizeOption>,
     pub syntax_highlight_theme: Option<String>,
     pub syntax_highlight_inline_style: Option<bool>,
 }

--- a/native/comrak_nif/src/types/options/sanitize.rs
+++ b/native/comrak_nif/src/types/options/sanitize.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::type_complexity)]
+
 use std::{
     borrow::Borrow,
     collections::{HashMap, HashSet},

--- a/native/comrak_nif/src/types/options/sanitize.rs
+++ b/native/comrak_nif/src/types/options/sanitize.rs
@@ -239,29 +239,6 @@ impl ExSanitizeCustomSetAddRm<HashMap<String, HashMap<String, Vec<String>>>> {
     }
 }
 
-// For some options, we want to take an optional string, but we want to
-// distinguish a user `nil` from the user not passing any value at all. The
-// unary unit enum below makes the value `:unset` decodable as part of the
-// untagged enum below that.
-
-#[derive(Clone, Debug, NifUnitEnum)]
-pub enum ExSanitizeCustomUnset {
-    Unset,
-}
-
-// `:unset`, `nil` or an Elixir String.
-#[derive(Debug, NifUntaggedEnum)]
-pub enum ExSanitizeCustomMaybeString {
-    Unset(ExSanitizeCustomUnset),
-    Set(Option<String>),
-}
-
-impl Default for ExSanitizeCustomMaybeString {
-    fn default() -> Self {
-        Self::Unset(ExSanitizeCustomUnset::Unset)
-    }
-}
-
 #[derive(Debug, NifTaggedEnum)]
 pub enum ExSanitizeCustomUrlRelative {
     Deny,
@@ -308,8 +285,8 @@ pub struct ExSanitizeCustom {
         HashMap<String, String>,
     >,
     pub strip_comments: Option<bool>,
-    pub link_rel: ExSanitizeCustomMaybeString,
-    pub id_prefix: ExSanitizeCustomMaybeString,
+    pub link_rel: Option<String>,
+    pub id_prefix: Option<String>,
     pub url_relative: Option<ExSanitizeCustomUrlRelative>,
     // attribute_filter is also available in ammonia.
 }
@@ -375,12 +352,8 @@ impl ExSanitizeCustom {
         if let Some(strip_comments) = self.strip_comments {
             builder.strip_comments(strip_comments);
         }
-        if let ExSanitizeCustomMaybeString::Set(link_rel) = &self.link_rel {
-            builder.link_rel(link_rel.as_ref().map(|s| s.borrow()));
-        }
-        if let ExSanitizeCustomMaybeString::Set(id_prefix) = &self.id_prefix {
-            builder.id_prefix(id_prefix.as_ref().map(|s| s.borrow()));
-        }
+        builder.link_rel(self.link_rel.as_ref().map(|s| s.borrow()));
+        builder.id_prefix(self.id_prefix.as_ref().map(|s| s.borrow()));
         if let Some(url_relative) = &self.url_relative {
             builder.url_relative(url_relative.to_ammonia());
         }

--- a/native/comrak_nif/src/types/options/sanitize.rs
+++ b/native/comrak_nif/src/types/options/sanitize.rs
@@ -1,0 +1,390 @@
+use std::{
+    borrow::Borrow,
+    collections::{HashMap, HashSet},
+};
+
+use ammonia::{Builder, Url, UrlRelative};
+
+// Utility functions to turn e.g. &'a Vec<String> into HashSet<&'a str>,
+// &'a HashMap<String, String> into HashMap<&'a str, &'a str>, etc.
+//
+// We use the former types because they store our options from Elixir nicely
+// (with automatic Decoder impls from rustler), and the latter types are what
+// ammonia take.
+//
+// These could be written with concrete inputs (&Vec<String> instead of <I:
+// IntoIterator<...>>), but this gives us some flexibility later if we decide to
+// change the storage.
+
+fn borrowed_set<'a, I, K>(it: I) -> HashSet<&'a str>
+where
+    I: IntoIterator<Item = &'a K>,
+    K: 'a + ?Sized + Borrow<str>,
+{
+    it.into_iter().map(|s| s.borrow()).collect()
+}
+
+fn borrowed_map<'a, I, K, V>(it: I) -> HashMap<&'a str, &'a str>
+where
+    I: IntoIterator<Item = (&'a K, &'a V)>,
+    K: 'a + ?Sized + Borrow<str>,
+    V: 'a + ?Sized + Borrow<str>,
+{
+    it.into_iter()
+        .map(|(key, val)| (key.borrow(), val.borrow()))
+        .collect()
+}
+
+fn borrowed_map_set<'a, KI, K, VI, V>(it: KI) -> HashMap<&'a str, HashSet<&'a str>>
+where
+    KI: IntoIterator<Item = (&'a K, VI)>,
+    K: 'a + ?Sized + Borrow<str>,
+    VI: IntoIterator<Item = &'a V>,
+    V: 'a + ?Sized + Borrow<str>,
+{
+    it.into_iter()
+        .map(|(key, vals)| (key.borrow(), borrowed_set(vals)))
+        .collect()
+}
+
+fn borrowed_map_map<'a, TI, T, AI, A, V>(it: TI) -> HashMap<&'a str, HashMap<&'a str, &'a str>>
+where
+    TI: IntoIterator<Item = (&'a T, AI)>,
+    T: 'a + ?Sized + Borrow<str>,
+    AI: IntoIterator<Item = (&'a A, &'a V)>,
+    A: 'a + ?Sized + Borrow<str>,
+    V: 'a + ?Sized + Borrow<str>,
+{
+    it.into_iter()
+        .map(|(key, vals)| (key.borrow(), borrowed_map(vals)))
+        .collect()
+}
+
+fn borrowed_map_map_set<'a, TI, T, AI, A, VI, V>(
+    it: TI,
+) -> HashMap<&'a str, HashMap<&'a str, HashSet<&'a str>>>
+where
+    TI: IntoIterator<Item = (&'a T, AI)>,
+    T: 'a + ?Sized + Borrow<str>,
+    AI: IntoIterator<Item = (&'a A, VI)>,
+    A: 'a + ?Sized + Borrow<str>,
+    VI: IntoIterator<Item = &'a V>,
+    V: 'a + ?Sized + Borrow<str>,
+{
+    it.into_iter()
+        .map(|(key, vals)| (key.borrow(), borrowed_map_set(vals)))
+        .collect()
+}
+
+#[derive(Debug, NifUnitEnum, Default)]
+pub enum ExSanitizeCustomBase {
+    #[default]
+    Default,
+
+    Empty,
+}
+
+impl ExSanitizeCustomBase {
+    fn to_ammonia(&self) -> Builder<'_> {
+        match self {
+            ExSanitizeCustomBase::Default => Builder::default(),
+            ExSanitizeCustomBase::Empty => Builder::empty(),
+        }
+    }
+}
+
+// ammonia exposes many options which can be set (discard previous value,
+// assign new one), added to (append/merge with previous value), or removed
+// from (subtract from previous value).  We let the user choose which of these
+// operations they want by saying `option: [set: ..., add: ..., rm: ...]`.
+//
+// Most operate with the same shape of value in all three modes, but
+// set_tag_attribute_values is different.
+
+#[derive(Debug, NifStruct, Default)]
+#[module = "MDEx.Types.SanitizeCustomSetAddRm"]
+pub struct ExSanitizeCustomSetAddRm<TSet, TAdd = TSet, TRm = TSet> {
+    set: Option<TSet>,
+    add: Option<TAdd>,
+    rm: Option<TRm>,
+}
+
+// How such options actually function depends on the shape of value they
+// actually manipulate. We write an "apply" implementation for each type used.
+//
+// The higher-ranked bounds used in the function pointer types make it possible
+// for us to pass the builder reference into each of them without the borrow
+// lasting as long as a lifetime parameter on the apply function itself (and
+// therefore overlapping).
+
+impl ExSanitizeCustomSetAddRm<Vec<String>> {
+    fn apply<'a>(
+        &'a self,
+        builder: &mut Builder<'a>,
+        set_fn: for<'r> fn(&'r mut Builder<'a>, HashSet<&'a str>) -> &'r mut Builder<'a>,
+        add_fn: for<'r> fn(&'r mut Builder<'a>, HashSet<&'a str>) -> &'r mut Builder<'a>,
+        rm_fn: for<'r> fn(&'r mut Builder<'a>, HashSet<&'a str>) -> &'r mut Builder<'a>,
+    ) {
+        if let Some(set) = &self.set {
+            set_fn(builder, borrowed_set(set));
+        }
+        if let Some(add) = &self.add {
+            add_fn(builder, borrowed_set(add));
+        }
+        if let Some(rm) = &self.rm {
+            rm_fn(builder, borrowed_set(rm));
+        }
+    }
+}
+impl ExSanitizeCustomSetAddRm<HashMap<String, Vec<String>>> {
+    fn apply<'a>(
+        &'a self,
+        builder: &mut Builder<'a>,
+        set_fn: for<'r> fn(
+            &'r mut Builder<'a>,
+            HashMap<&'a str, HashSet<&'a str>>,
+        ) -> &'r mut Builder<'a>,
+        add_fn: for<'r> fn(&'r mut Builder<'a>, &'a str, HashSet<&'a str>) -> &'r mut Builder<'a>,
+        rm_fn: for<'r> fn(&'r mut Builder<'a>, &'a str, HashSet<&'a str>) -> &'r mut Builder<'a>,
+    ) {
+        if let Some(set) = &self.set {
+            set_fn(builder, borrowed_map_set(set));
+        }
+        if let Some(add) = &self.add {
+            for (tag, attrs) in add {
+                add_fn(builder, tag, borrowed_set(attrs));
+            }
+        }
+        if let Some(rm) = &self.rm {
+            for (tag, attrs) in rm {
+                rm_fn(builder, tag, borrowed_set(attrs));
+            }
+        }
+    }
+}
+
+impl
+    ExSanitizeCustomSetAddRm<
+        HashMap<String, HashMap<String, String>>,
+        HashMap<String, HashMap<String, String>>,
+        HashMap<String, String>,
+    >
+{
+    fn apply<'a>(
+        &'a self,
+        builder: &mut Builder<'a>,
+        set_fn: for<'r> fn(
+            &'r mut Builder<'a>,
+            HashMap<&'a str, HashMap<&'a str, &'a str>>,
+        ) -> &'r mut Builder<'a>,
+        add_fn: for<'r> fn(&'r mut Builder<'a>, &'a str, &'a str, &'a str) -> &'r mut Builder<'a>,
+        rm_fn: for<'r> fn(&'r mut Builder<'a>, &'a str, &'a str) -> &'r mut Builder<'a>,
+    ) {
+        if let Some(set) = &self.set {
+            set_fn(builder, borrowed_map_map(set));
+        }
+        if let Some(add) = &self.add {
+            for (tag, attrs) in add {
+                for (attr, value) in attrs {
+                    add_fn(builder, tag, attr, value);
+                }
+            }
+        }
+        if let Some(rm) = &self.rm {
+            for (tag, attr) in rm {
+                rm_fn(builder, tag, attr);
+            }
+        }
+    }
+}
+
+impl ExSanitizeCustomSetAddRm<HashMap<String, HashMap<String, Vec<String>>>> {
+    fn apply<'a>(
+        &'a self,
+        builder: &mut Builder<'a>,
+        set_fn: for<'r> fn(
+            &'r mut Builder<'a>,
+            HashMap<&'a str, HashMap<&'a str, HashSet<&'a str>>>,
+        ) -> &'r mut Builder<'a>,
+        add_fn: for<'r> fn(
+            &'r mut Builder<'a>,
+            &'a str,
+            &'a str,
+            HashSet<&'a str>,
+        ) -> &'r mut Builder<'a>,
+        rm_fn: for<'r> fn(
+            &'r mut Builder<'a>,
+            &'a str,
+            &'a str,
+            HashSet<&'a str>,
+        ) -> &'r mut Builder<'a>,
+    ) {
+        if let Some(set) = &self.set {
+            set_fn(builder, borrowed_map_map_set(set));
+        }
+        if let Some(add) = &self.add {
+            for (tag, attrs) in add {
+                for (attr, values) in attrs {
+                    add_fn(builder, tag, attr, borrowed_set(values));
+                }
+            }
+        }
+        if let Some(rm) = &self.rm {
+            for (tag, attrs) in rm {
+                for (attr, values) in attrs {
+                    rm_fn(builder, tag, attr, borrowed_set(values));
+                }
+            }
+        }
+    }
+}
+
+// For some options, we want to take an optional string, but we want to
+// distinguish a user `nil` from the user not passing any value at all. The
+// unary unit enum below makes the value `:unset` decodable as part of the
+// untagged enum below that.
+
+#[derive(Clone, Debug, NifUnitEnum)]
+pub enum ExSanitizeCustomUnset {
+    Unset,
+}
+
+// `:unset`, `nil` or an Elixir String.
+#[derive(Debug, NifUntaggedEnum)]
+pub enum ExSanitizeCustomMaybeString {
+    Unset(ExSanitizeCustomUnset),
+    Set(Option<String>),
+}
+
+impl Default for ExSanitizeCustomMaybeString {
+    fn default() -> Self {
+        Self::Unset(ExSanitizeCustomUnset::Unset)
+    }
+}
+
+#[derive(Debug, NifTaggedEnum)]
+pub enum ExSanitizeCustomUrlRelative {
+    Deny,
+    Passthrough,
+    RewriteWithBase(String),
+    RewriteWithRoot((String, String)),
+    // Custom is also available in ammonia.
+}
+
+impl ExSanitizeCustomUrlRelative {
+    fn to_ammonia(&self) -> UrlRelative {
+        match self {
+            &ExSanitizeCustomUrlRelative::Deny => UrlRelative::Deny,
+            &ExSanitizeCustomUrlRelative::Passthrough => UrlRelative::PassThrough,
+            ExSanitizeCustomUrlRelative::RewriteWithBase(base) => UrlRelative::RewriteWithBase(
+                Url::parse(base).expect(":rewrite_with_base base URL valid"),
+            ),
+            ExSanitizeCustomUrlRelative::RewriteWithRoot((root, path)) => {
+                UrlRelative::RewriteWithRoot {
+                    root: Url::parse(root).expect(":rewrite_with_root root URL valid"),
+                    path: path.to_string(),
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, NifStruct, Default)]
+#[module = "MDEx.Types.SanitizeCustom"]
+pub struct ExSanitizeCustom {
+    pub base: ExSanitizeCustomBase,
+    pub tags: ExSanitizeCustomSetAddRm<Vec<String>>,
+    pub clean_content_tags: ExSanitizeCustomSetAddRm<Vec<String>>,
+    pub tag_attributes: ExSanitizeCustomSetAddRm<HashMap<String, Vec<String>>>,
+    pub tag_attribute_values:
+        ExSanitizeCustomSetAddRm<HashMap<String, HashMap<String, Vec<String>>>>,
+    pub generic_attribute_prefixes: ExSanitizeCustomSetAddRm<Vec<String>>,
+    pub generic_attributes: ExSanitizeCustomSetAddRm<Vec<String>>,
+    pub url_schemes: ExSanitizeCustomSetAddRm<Vec<String>>,
+    pub allowed_classes: ExSanitizeCustomSetAddRm<HashMap<String, Vec<String>>>,
+    pub set_tag_attribute_values: ExSanitizeCustomSetAddRm<
+        HashMap<String, HashMap<String, String>>,
+        HashMap<String, HashMap<String, String>>,
+        HashMap<String, String>,
+    >,
+    pub strip_comments: Option<bool>,
+    pub link_rel: ExSanitizeCustomMaybeString,
+    pub id_prefix: ExSanitizeCustomMaybeString,
+    pub url_relative: Option<ExSanitizeCustomUrlRelative>,
+    // attribute_filter is also available in ammonia.
+}
+
+impl ExSanitizeCustom {
+    pub fn to_ammonia(&self) -> Builder<'_> {
+        let mut builder = self.base.to_ammonia();
+
+        self.tags.apply(
+            &mut builder,
+            Builder::tags,
+            Builder::add_tags,
+            Builder::rm_tags,
+        );
+        self.clean_content_tags.apply(
+            &mut builder,
+            Builder::clean_content_tags,
+            Builder::add_clean_content_tags,
+            Builder::rm_clean_content_tags,
+        );
+        self.tag_attributes.apply(
+            &mut builder,
+            Builder::tag_attributes,
+            Builder::add_tag_attributes,
+            Builder::rm_tag_attributes,
+        );
+        self.tag_attribute_values.apply(
+            &mut builder,
+            Builder::tag_attribute_values,
+            Builder::add_tag_attribute_values,
+            Builder::rm_tag_attribute_values,
+        );
+        self.generic_attribute_prefixes.apply(
+            &mut builder,
+            Builder::generic_attribute_prefixes,
+            Builder::add_generic_attribute_prefixes,
+            Builder::rm_generic_attribute_prefixes,
+        );
+        self.generic_attributes.apply(
+            &mut builder,
+            Builder::generic_attributes,
+            Builder::add_generic_attributes,
+            Builder::rm_generic_attributes,
+        );
+        self.url_schemes.apply(
+            &mut builder,
+            Builder::url_schemes,
+            Builder::add_url_schemes,
+            Builder::rm_url_schemes,
+        );
+        self.allowed_classes.apply(
+            &mut builder,
+            Builder::allowed_classes,
+            Builder::add_allowed_classes,
+            Builder::rm_allowed_classes,
+        );
+        self.set_tag_attribute_values.apply(
+            &mut builder,
+            Builder::set_tag_attribute_values,
+            Builder::set_tag_attribute_value,
+            Builder::rm_set_tag_attribute_value,
+        );
+        if let Some(strip_comments) = self.strip_comments {
+            builder.strip_comments(strip_comments);
+        }
+        if let ExSanitizeCustomMaybeString::Set(link_rel) = &self.link_rel {
+            builder.link_rel(link_rel.as_ref().map(|s| s.borrow()));
+        }
+        if let ExSanitizeCustomMaybeString::Set(id_prefix) = &self.id_prefix {
+            builder.id_prefix(id_prefix.as_ref().map(|s| s.borrow()));
+        }
+        if let Some(url_relative) = &self.url_relative {
+            builder.url_relative(url_relative.to_ammonia());
+        }
+
+        builder
+    }
+}

--- a/test/mdex_test.exs
+++ b/test/mdex_test.exs
@@ -217,14 +217,14 @@ defmodule MDExTest do
                features: [
                  sanitize: [
                    base: :empty,
-                   tags: [set: ["h1"], add: ["a", "strong"], rm: ["strong"]],
-                   clean_content_tags: [add: ["script"]],
-                   tag_attributes: [add: %{"h1" => ["data-val"]}],
-                   tag_attribute_values: [add: %{"h1" => %{"data-x" => ["3"]}}],
-                   generic_attribute_prefixes: [set: ["x-"]],
-                   generic_attributes: [set: ["id"]],
-                   allowed_classes: [set: %{"h1" => ["xyz"]}],
-                   set_tag_attribute_values: [set: %{"h1" => %{"hello" => "world"}}, add: %{"h1" => %{"ola" => "mundo"}}, rm: %{"h1" => "hello"}],
+                   tags: %{set: ["h1"], add: ["a", "strong"], rm: ["strong"]},
+                   clean_content_tags: %{add: ["script"]},
+                   tag_attributes: %{add: %{"h1" => ["data-val"]}},
+                   tag_attribute_values: %{add: %{"h1" => %{"data-x" => ["3"]}}},
+                   generic_attribute_prefixes: %{set: ["x-"]},
+                   generic_attributes: %{set: ["id"]},
+                   allowed_classes: %{set: %{"h1" => ["xyz"]}},
+                   set_tag_attribute_values: %{set: %{"h1" => %{"hello" => "world"}}, add: %{"h1" => %{"ola" => "mundo"}}, rm: %{"h1" => "hello"}},
                    strip_comments: false,
                    link_rel: "no",
                    id_prefix: "user-content-"

--- a/test/mdex_test.exs
+++ b/test/mdex_test.exs
@@ -193,6 +193,74 @@ defmodule MDExTest do
                "<p><a href=\"https://elixir-lang.org/\" rel=\"noopener noreferrer\"></a></p>"
     end
 
+    test "range of sanitize specifications" do
+      input = ~s"""
+      <h1 class="abc xyz" e="f" f="g" data-val="1" x-val="2" data-x="3">
+      <strong>te<!-- :) -->st</strong> <a id="elixir" href="https://elixir-lang.org/"></a>
+      </h1>
+      """
+
+      assert MDEx.to_html!(input, render: [unsafe_: true], features: [sanitize: true]) <> "\n" == ~s"""
+             <h1>
+             <strong>test</strong> <a href="https://elixir-lang.org/" rel="noopener noreferrer"></a>
+             </h1>
+             """
+
+      assert MDEx.to_html!(input, render: [unsafe_: true], features: [sanitize: :clean]) <> "\n" == ~s"""
+             <h1>
+             <strong>test</strong> <a href="https://elixir-lang.org/" rel="noopener noreferrer"></a>
+             </h1>
+             """
+
+      assert MDEx.to_html!(input,
+               render: [unsafe_: true],
+               features: [
+                 sanitize: [
+                   base: :empty,
+                   tags: [set: ["h1"], add: ["a", "strong"], rm: ["strong"]],
+                   clean_content_tags: [add: ["script"]],
+                   tag_attributes: [add: %{"h1" => ["data-val"]}],
+                   tag_attribute_values: [add: %{"h1" => %{"data-x" => ["3"]}}],
+                   generic_attribute_prefixes: [set: ["x-"]],
+                   generic_attributes: [set: ["id"]],
+                   allowed_classes: [set: %{"h1" => ["xyz"]}],
+                   set_tag_attribute_values: [set: %{"h1" => %{"hello" => "world"}}, add: %{"h1" => %{"ola" => "mundo"}}, rm: %{"h1" => "hello"}],
+                   strip_comments: false,
+                   link_rel: "no",
+                   id_prefix: "user-content-"
+                 ]
+               ]
+             ) <> "\n" == ~s"""
+             <h1 class="xyz" data-val="1" x-val="2" data-x="3" ola="mundo">
+             te<!-- :) -->st <a id="user-content-elixir" href="https://elixir-lang.org/" rel="no"></a>
+             </h1>
+             """
+
+      assert MDEx.to_html!(
+               ~s"""
+               <p>
+               <a href="">empty</a>
+               <a href="/">root</a>
+               <a href="https://host/">elsewhere</a>
+               </p>
+               """,
+               render: [unsafe_: true],
+               features: [
+                 sanitize: [
+                   base: :default,
+                   link_rel: nil,
+                   url_relative: {:rewrite_with_root, {"https://example/root/", "index.html"}}
+                 ]
+               ]
+             ) <> "\n" == ~s"""
+             <p>
+             <a href="https://example/root/index.html">empty</a>
+             <a href="https://example/root/">root</a>
+             <a href="https://host/">elsewhere</a>
+             </p>
+             """
+    end
+
     test "encode curly braces in inline code" do
       assert_output(
         ~S"""


### PR DESCRIPTION
Hoping to fix #135!

Please take a look and let me know what you think. Rather than limiting ourselves to only a few ways of interacting with the ammonia presets, I decided to give access to both their presets (default and "empty"), and to the full set of setters/adders/removers for each. I've skipped on extensive documentation for now, until we're sure this is the way forward.

There are likely to be some clippy warnings about Big Types. Let me know how you'd like to approach these.