### PR TITLE
Expose comrak's Anchorizer as text_to_anchor, for use in ToCs and similar areas

### DIFF
--- a/lib/mdex.ex
+++ b/lib/mdex.ex
@@ -581,7 +581,7 @@ defmodule MDEx do
         Apply syntax highlighting to code blocks.
 
         Examples:
-        
+
             syntax_highlight: [formatter: {:html_inline, theme: "github_dark"}]
 
             syntax_highlight: [formatter: {:html_linked, theme: "github_light"}]
@@ -1654,4 +1654,35 @@ defmodule MDEx do
     ])
     |> Pipe.put_options(options)
   end
+
+  @doc """
+  Converts a given `text` string to a format that can be used as an "anchor",
+  such as in a Table of Contents.
+
+  This uses the same algorithim GFM uses for anchor ids, so it can be used
+  reliably.
+
+  > [!NOTE]
+  > GFM will dedupe multiple repeated anchors with the same value by appending
+  > an incrementing number to the end of the anchor. That is beyond the scope of
+  > this function, so you will have to handle it yourself
+
+  ## Examples
+
+      iex> MDEx.anchorize("Hello World")
+      "hello-world"
+
+      iex> MDEx.anchorize("Hello, World!")
+      "hello-world"
+
+      iex> MDEx.anchorize("Hello -- World")
+      "hello----world"
+
+      iex> MDEx.anchorize("Hello World 123")
+      "hello-world-123"
+
+      iex> MDEx.anchorize("你好世界")
+      "你好世界"
+  """
+  defdelegate anchorize(string), to: Native, as: :text_to_anchor
 end

--- a/lib/mdex/native.ex
+++ b/lib/mdex/native.ex
@@ -77,4 +77,8 @@ defmodule MDEx.Native do
   def document_to_html_with_options(_doc, _opts), do: :erlang.nif_error(:nif_not_loaded)
   def document_to_xml(_doc), do: :erlang.nif_error(:nif_not_loaded)
   def document_to_xml_with_options(_doc, _opts), do: :erlang.nif_error(:nif_not_loaded)
+
+  # util
+  #   - text_to_anchor
+  def text_to_anchor(_text), do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/native/comrak_nif/src/lib.rs
+++ b/native/comrak_nif/src/lib.rs
@@ -325,8 +325,7 @@ fn do_safe_html(
 
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn text_to_anchor(env: Env<'_>, text: String) -> NifResult<Term<'_>> {
+pub fn text_to_anchor(env: Env<'_>, text: String) -> String {
     let mut anchorizer = Anchorizer::new();
-    let anchor = anchorizer.anchorize(text);
-    Ok((ok(), anchor).encode(env))
+    anchorizer.anchorize(text)
 }

--- a/native/comrak_nif/src/lib.rs
+++ b/native/comrak_nif/src/lib.rs
@@ -10,7 +10,7 @@ mod types;
 use autumnus_adapter::AutumnusAdapter;
 use comrak::html::{ChildRendering, Context};
 use comrak::{create_formatter, nodes::NodeValue};
-use comrak::{Arena, ComrakPlugins, Options};
+use comrak::{Anchorizer, Arena, ComrakPlugins, Options};
 use lol_html::html_content::ContentType;
 use lol_html::{rewrite_str, text, RewriteStrSettings};
 use rustler::{Encoder, Env, NifResult, Term};
@@ -321,4 +321,12 @@ fn do_safe_html(
     // TODO: not so clean solution to undo double escaping, could be better
     html.replace("&amp;lbrace;", "&lbrace;")
         .replace("&amp;rbrace;", "&rbrace;")
+}
+
+
+#[rustler::nif(schedule = "DirtyCpu")]
+pub fn text_to_anchor(env: Env<'_>, text: String) -> NifResult<Term<'_>> {
+    let mut anchorizer = Anchorizer::new();
+    let anchor = anchorizer.anchorize(text);
+    Ok((ok(), anchor).encode(env))
 }

--- a/native/comrak_nif/src/lib.rs
+++ b/native/comrak_nif/src/lib.rs
@@ -323,7 +323,6 @@ fn do_safe_html(
         .replace("&amp;rbrace;", "&rbrace;")
 }
 
-
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn text_to_anchor(env: Env<'_>, text: String) -> String {
     let mut anchorizer = Anchorizer::new();


### PR DESCRIPTION
Exposes Comrak's [anchorizer](https://github.com/kivikakk/comrak/blob/main/src/html/anchorizer.rs). This allows one to build a Table of Contents off markdown documents, and use the same algo that is used by the HTML renderer, rather than having to implement one yourself (even if its [rather trivial](https://github.com/paradox460/pdx.su/blob/c9772179b30ebfee6d7b6bcb30bdeb50a144dd8e/lib/extensions/toc.ex#L43-L56))

Note that due to how this function is exposed to the nif, the de-duping feature of Anchorizer doesn't work. You could probably make it work rather easily, but you'd have to have a way to reset the context when calling the nif from elixir, otherwise all your anchors would have to be world-unique, not just context unique
