### PR TITLE
fix delta_converter: add support for extra newlines between consecutive paragraphs

### DIFF
--- a/lib/mdex/delta_converter.ex
+++ b/lib/mdex/delta_converter.ex
@@ -46,7 +46,16 @@ defmodule MDEx.DeltaConverter do
   defp convert_nodes([node | rest], current_attrs, options) do
     node_ops = convert_node(node, current_attrs, options)
     rest_ops = convert_nodes(rest, current_attrs, options)
-    node_ops ++ rest_ops
+
+    # Add extra newline between consecutive paragraphs only
+    case {node, rest} do
+      {%MDEx.Paragraph{}, [%MDEx.Paragraph{} | _]} ->
+        # Paragraph followed by another paragraph - add extra newline for visual separation
+        node_ops ++ [%{"insert" => "\n"}] ++ rest_ops
+
+      _ ->
+        node_ops ++ rest_ops
+    end
   end
 
   # Convert individual nodes to delta operations

--- a/test/mdex/delta_integration_test.exs
+++ b/test/mdex/delta_integration_test.exs
@@ -127,11 +127,11 @@ defmodule MDEx.DeltaIntegrationTest do
 
       function useCounter(initialValue = 0) {
         const [count, setCount] = useState(initialValue);
-        
+
         useEffect(() => {
           document.title = `Count: ${count}`;
         }, [count]);
-        
+
         return [count, setCount];
       }
       ```
@@ -208,7 +208,7 @@ defmodule MDEx.DeltaIntegrationTest do
       The API returns standard HTTP status codes:
 
       - `200` - Success
-      - `400` - Bad Request  
+      - `400` - Bad Request
       - `401` - Unauthorized
       - `500` - Internal Server Error
 
@@ -267,7 +267,7 @@ defmodule MDEx.DeltaIntegrationTest do
       ## Text Formatting
 
       - **Bold text**
-      - *Italic text*  
+      - *Italic text*
       - ~~Strikethrough~~
       - ++Underlined++
       - `inline code`
@@ -310,7 +310,7 @@ defmodule MDEx.DeltaIntegrationTest do
       ## Block Elements
 
       > This is a blockquote with some **bold** text inside.
-      > 
+      >
       > It can span multiple paragraphs.
 
       ---
@@ -587,6 +587,38 @@ defmodule MDEx.DeltaIntegrationTest do
 
       assert result == [
                %{"insert" => "Hello world"},
+               %{"insert" => "\n"}
+             ]
+    end
+
+    test "paragraph spacing preserves blank lines" do
+      input = """
+      First paragraph.
+
+      Second paragraph after blank line.
+
+      Third paragraph.
+      """
+
+      # Let's first see how the parser structures this
+      {:ok, ast} = MDEx.parse_document(input, extension: @extension)
+
+      {:ok, result} = parse_with_extensions(input)
+
+      # Expected: paragraphs should have proper spacing between them
+      assert result == [
+               %{"insert" => "First paragraph."},
+               # End first paragraph
+               %{"insert" => "\n"},
+               # Extra space before next paragraph
+               %{"insert" => "\n"},
+               %{"insert" => "Second paragraph after blank line."},
+               # End second paragraph
+               %{"insert" => "\n"},
+               # Extra space before next paragraph
+               %{"insert" => "\n"},
+               %{"insert" => "Third paragraph."},
+               # End final paragraph
                %{"insert" => "\n"}
              ]
     end


### PR DESCRIPTION
Current solution has a bug where there are no two newlines between two consecutive paragraphs. They're rendered incorrectly in the Quill editor.