### PR TITLE
feat(doc): access by index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
   - [Document] Add pretty print inspection for document AST
+  - [Document] Add access by integer index for nodes in depth-first traversal order
 
 ### Fixed
   - [Collectable] Fix inline node merging

--- a/lib/mdex/document.ex
+++ b/lib/mdex/document.ex
@@ -210,6 +210,30 @@ defmodule MDEx.Document do
   The `Access` behaviour gives you the ability to fetch and update nodes using different types of keys.
   Access operations also follow the depth-first traversal order when searching through nodes.
 
+  ### Access by Index
+
+  You can access nodes by their position in the depth-first traversal using integer indices:
+
+  ```elixir
+  iex> doc = ~MD[# Hello]
+  iex> doc[0]  # First node (the document itself)
+  %MDEx.Document{nodes: [%MDEx.Heading{nodes: [%MDEx.Text{literal: "Hello"}], level: 1, setext: false}]}
+  iex> doc[1]  # Second node (the heading)
+  %MDEx.Heading{nodes: [%MDEx.Text{literal: "Hello"}], level: 1, setext: false}
+  iex> doc[2]  # Third node (the text)
+  %MDEx.Text{literal: "Hello"}
+  ```
+
+  Negative indices access nodes from the end:
+
+  ```elixir
+  iex> doc = ~MD[# Hello **world**]
+  iex> doc[-1]  # Last node
+  %MDEx.Text{literal: "world"}
+  ```
+
+  ### Access by Node Type
+
   Starting with a simple Markdown document, let's fetch only the text node by matching the `MDEx.Text` node:
 
   ```elixir

--- a/lib/mdex/document/access.ex
+++ b/lib/mdex/document/access.ex
@@ -39,6 +39,13 @@ defmodule MDEx.Document.Access do
     end
   end
 
+  def fetch(document, selector) when is_integer(selector) do
+    case Enum.at(document, selector) do
+      nil -> :error
+      node -> {:ok, node}
+    end
+  end
+
   def get_and_update(document, selector, fun) when is_struct(selector) do
     {document, {_, old}} =
       MDEx.Document.Traversal.traverse_and_update(document, {:cont, nil}, fn
@@ -97,6 +104,17 @@ defmodule MDEx.Document.Access do
     {old, document}
   end
 
+  def get_and_update(document, selector, fun) when is_integer(selector) do
+    node = Enum.at(document, selector)
+
+    if node do
+      {old, _new} = fun.(node)
+      {old, document}
+    else
+      {nil, document}
+    end
+  end
+
   def pop(document, key, default \\ nil)
 
   def pop(document, key, default) when is_struct(key) do
@@ -135,6 +153,11 @@ defmodule MDEx.Document.Access do
       end)
 
     {old || default, new}
+  end
+
+  def pop(document, key, default) when is_integer(key) do
+    node = Enum.at(document, key)
+    {node || default, document}
   end
 
   @doc false


### PR DESCRIPTION
`~MD[# Hello][1]`