### PR TITLE
Fix formatting in sigil.ex documentation

### DIFF
--- a/lib/mdex/sigil.ex
+++ b/lib/mdex/sigil.ex
@@ -96,17 +96,17 @@ defmodule MDEx.Sigil do
 
     * `HTML` - converts Markdown or `MDEx.Document` to HTML
 
-    Use [EEx.SmartEngine](https://hexdocs.pm/eex/EEx.SmartEngine.html) to convert the document into HTML. It does support `assigns` but only the old `<%= ... %>` syntax,
-    and it doesn't support components. It's useful if you want to generate static HTML from Markdown or don't need components or don't want to define an `assigns` variable (it's optional).
+        Use [EEx.SmartEngine](https://hexdocs.pm/eex/EEx.SmartEngine.html) to convert the document into HTML. It does support `assigns` but only the old `<%= ... %>` syntax,
+        and it doesn't support components. It's useful if you want to generate static HTML from Markdown or don't need components or don't want to define an `assigns` variable (it's optional).
 
-    Prefer using the `HEEX` modifier if you need full Phoenix LiveView support with components and expressions.
+        Prefer using the `HEEX` modifier if you need full Phoenix LiveView support with components and expressions.
 
     * `HEEX` - converts Markdown to [Phoenix HEEx](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.Rendered.html) for LiveView templates
 
-    Enables LiveView components, `phx-*` bindings, and Elixir expressions inside Markdown.
-    Requires Phoenix LiveView and an `assigns` variable in scope.
+        Enables LiveView components, `phx-*` bindings, and Elixir expressions inside Markdown.
+        Requires Phoenix LiveView and an `assigns` variable in scope.
 
-    See [Phoenix LiveView HEEx example](https://hexdocs.pm/mdex/phoenix_live_view_heex.html) for a demo.
+        See [Phoenix LiveView HEEx example](https://hexdocs.pm/mdex/phoenix_live_view_heex.html) for a demo.
 
     * `JSON` - converts Markdown or `MDEx.Document` to JSON
 


### PR DESCRIPTION
Correctly indent item text. Noticed this while reading the documentation:

<img width="2742" height="2028" alt="CleanShot 2026-01-11 at 16 07 40@2x" src="https://github.com/user-attachments/assets/c9796ceb-f899-460e-9007-a2f2c80b91b2" />
