### PR TITLE
fix: do not wrap plaintext code in <span>

### DIFF
--- a/native/comrak_nif/src/lumis_adapter.rs
+++ b/native/comrak_nif/src/lumis_adapter.rs
@@ -413,6 +413,7 @@ impl SyntaxHighlighterAdapter for LumisAdapter {
         } else {
             Language::guess(Some("plaintext"), source)
         };
+        let is_plaintext = language == Language::PlainText;
 
         let theme = self
             .decorator_theme()
@@ -443,7 +444,7 @@ impl SyntaxHighlighterAdapter for LumisAdapter {
                 if text.trim().is_empty() {
                     html_output.push_str(text);
                 } else {
-                    let span = if is_linked {
+                    let span = if is_linked && !is_plaintext {
                         html::span_linked(text, scope)
                     } else if is_multi_themes {
                         if let Some(ref config) = multi_themes_config {
@@ -563,6 +564,33 @@ fn main() {
         let expected = r#"<pre class="athl"><code class="language-rust" translate="no" tabindex="0"><div class="line" data-line="1">fn main() &lbrace;
 </div><div class="line" data-line="2">    let message = &quot;Hello, world!&quot;;
 </div><div class="line" data-line="3">&rbrace;
+</div></code></pre>"#;
+
+        assert_str_eq!(output.trim(), expected.trim());
+    }
+
+    #[test]
+    fn test_html_inline_plaintext() {
+        let markdown = r#"
+```
+plain
+text
+```
+"#;
+
+        let formatter = ExFormatterOption::HtmlInline {
+            theme: None,
+            pre_class: None,
+            italic: false,
+            include_highlights: false,
+            highlight_lines: None,
+            header: None,
+        };
+
+        let output = run_test(markdown, formatter, Options::default());
+
+        let expected = r#"<pre class="athl"><code class="language-plaintext" translate="no" tabindex="0"><div class="line" data-line="1">plain
+</div><div class="line" data-line="2">text
 </div></code></pre>"#;
 
         assert_str_eq!(output.trim(), expected.trim());
@@ -725,6 +753,30 @@ fn main() {
         let expected = r#"<pre class="athl"><code class="language-rust" translate="no" tabindex="0"><div class="line" data-line="1"><span class="keyword-function">fn</span> <span class="function">main</span><span class="punctuation-bracket">(</span><span class="punctuation-bracket">)</span> <span class="punctuation-bracket">&lbrace;</span>
 </div><div class="line" data-line="2">    <span class="keyword">let</span> <span class="variable">message</span> <span class="operator">=</span> <span class="string">&quot;Hello, world!&quot;</span><span class="punctuation-delimiter">;</span>
 </div><div class="line" data-line="3"><span class="punctuation-bracket">&rbrace;</span>
+</div></code></pre>"#;
+
+        assert_str_eq!(output.trim(), expected.trim());
+    }
+
+    #[test]
+    fn test_html_linked_plaintext() {
+        let markdown = r#"
+```
+plain
+text
+```
+"#;
+
+        let formatter = ExFormatterOption::HtmlLinked {
+            pre_class: None,
+            highlight_lines: None,
+            header: None,
+        };
+
+        let output = run_test(markdown, formatter, Options::default());
+
+        let expected = r#"<pre class="athl"><code class="language-plaintext" translate="no" tabindex="0"><div class="line" data-line="1">plain
+</div><div class="line" data-line="2">text
 </div></code></pre>"#;
 
         assert_str_eq!(output.trim(), expected.trim());

--- a/test/mdex/html_format_test.exs
+++ b/test/mdex/html_format_test.exs
@@ -47,6 +47,20 @@ defmodule MDEx.HTMLFormatTest do
     assert html == String.trim(expected)
   end
 
+  def assert_linked_format(document, expected, extension \\ []) do
+    opts = [
+      extension: Keyword.merge(@extension, extension),
+      syntax_highlight: [formatter: :html_linked],
+      render: [unsafe: true]
+    ]
+
+    assert {:ok, doc} = MDEx.parse_document(document, opts)
+    assert {:ok, html} = MDEx.to_html(doc, opts)
+
+    # IO.puts(html)
+    assert html == String.trim(expected)
+  end
+
   test "text" do
     assert_format("mdex", "<p>mdex</p>\n")
 
@@ -168,6 +182,36 @@ defmodule MDEx.HTMLFormatTest do
       """,
       """
       <pre class="athl" style="color: #abb2bf; background-color: #282c34;"><code class="language-elixir" translate="no" tabindex="0"><div class="line" data-line="1"><span style="color: #e5c07b;">String</span><span style="color: #56b6c2;">.</span><span style="color: #61afef;">trim</span><span style="color: #c678dd;">(</span><span style="color: #98c379;">&quot; MDEx &quot;</span><span style="color: #c678dd;">)</span>
+      </div></code></pre>
+      """
+    )
+  end
+
+  test "linked code block" do
+    assert_linked_format(
+      """
+      ```elixir
+      String.trim(" MDEx ")
+      ```
+      """,
+      """
+      <pre class="athl"><code class="language-elixir" translate="no" tabindex="0"><div class="line" data-line="1"><span class="module">String</span><span class="operator">.</span><span class="function-call">trim</span><span class="punctuation-bracket">(</span><span class="string">&quot; MDEx &quot;</span><span class="punctuation-bracket">)</span>
+      </div></code></pre>
+      """
+    )
+  end
+
+  test "linked plaintext block" do
+    assert_linked_format(
+      """
+      ```
+      plain
+      text
+      ```
+      """,
+      """
+      <pre class="athl"><code class="language-plaintext" translate="no" tabindex="0"><div class="line" data-line="1">plain
+      </div><div class="line" data-line="2">text
       </div></code></pre>
       """
     )


### PR DESCRIPTION
Hello there! Thank you very much for the library, I've been enjoying using it to do compile-time rendering for a few projects.

Starting in `v0.11`, combining unadorned fenced code blocks with the `:html_linked` formatter results in an extra blank line and some invalid HTML, in the form of an interleaved/wrapping `<span class="text">` element around the text itself.

This change reverts to the previous behaviour, and adds test cases to the Rust and Elixir layers to identify a regression.

#### MDEx v0.10.0:

    iex> MDEx.to_html!("```\nplain\ntext\n```", syntax_highlight: [formatter: :html_linked]) |> IO.puts
    <pre class="athl"><code class="language-plaintext" translate="no" tabindex="0"><div class="line" data-line="1">plain
    </div><div class="line" data-line="2">text
    </div></code></pre>

#### MDEx v0.11.5:

    iex> MDEx.to_html!("```\nplain\ntext\n```", syntax_highlight: [formatter: :html_linked]) |> IO.puts
    <pre class="athl"><code class="language-plaintext" translate="no" tabindex="0"><div class="line" data-line="1"><span class="text">plain
    </div><div class="line" data-line="2">text
    </div><div class="line" data-line="3"></span>
    </div></code></pre>

#### Changeset:

    iex> MDEx.to_html!("```\nplain\ntext\n```", syntax_highlight: [formatter: :html_linked]) |> IO.puts
    <pre class="athl"><code class="language-plaintext" translate="no" tabindex="0"><div class="line" data-line="1">plain
    </div><div class="line" data-line="2">text
    </div></code></pre>

## Additional Context

I get expected/correct HTML with the default inline styles, and when calling `Lumis` directly — it's only with the `html_linked` formatter that the problem occurs:

    iex> MDEx.to_html!("```\nplain\ntext\n```") |> IO.puts
    <pre class="athl" style="color: #abb2bf; background-color: #282c34;"><code class="language-plaintext" translate="no" tabindex="0"><div class="line" data-line="1">plain
    </div><div class="line" data-line="2">text
    </div></code></pre>

    iex> Lumis.highlight!("plain\ntext\n", language: "plaintext", formatter: :html_linked) |> IO.puts
    <pre class="lumis"><code class="language-plaintext" translate="no" tabindex="0"><div class="line" data-line="1">plain
    </div><div class="line" data-line="2">text
    </div></code></pre>