### PR TITLE
ci: use reusable hex publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,9 +5,6 @@ on:
     tags: ["v*"]
   workflow_dispatch:
 
-env:
-  MDEX_BUILD: "1"
-
 jobs:
   nif-release:
     uses: leandrocp/github-actions/.github/workflows/nif-release.yml@main
@@ -16,30 +13,12 @@ jobs:
       project-dir: native/comrak_nif
 
   hex-publish:
-    name: Publish to Hex
     needs: nif-release
     if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.ref }}
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - uses: erlef/setup-beam@v1
-        with:
-          otp-version: "28"
-          elixir-version: "1.19"
-
-      - name: Fetch dependencies
-        run: mix deps.get
-
-      - name: Generate checksums
-        run: mix rustler_precompiled.download MDEx.Native --all --print
-
-      - name: Publish to Hex
-        run: mix hex.publish --yes
-        env:
-          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
+    uses: leandrocp/github-actions/.github/workflows/hex-publish.yml@main
+    with:
+      env-vars: '{"MDEX_BUILD":"1"}'
+      install-rust: true
+      pre-publish-command: mix rustler_precompiled.download MDEx.Native --all --print
+    secrets:
+      HEX_API_KEY: ${{ secrets.HEX_API_KEY }}


### PR DESCRIPTION
## Summary
- switch the tag-based publish workflow to the shared `hex-publish.yml` reusable workflow
- keep the existing NIF release job and checksum generation by passing the extra shared workflow inputs needed by `mdex`
- depends on the pending `github-actions` update that adds those reusable workflow inputs