### PR TITLE
Fix streaming to preserve incomplete HTML across flushes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - [Streaming] Preserve chunk boundaries without synthetic newlines across flushes.
+- [Streaming] Preserve incomplete HTML across multiple flushes.
 
 ## [0.12.2](https://github.com/leandrocp/mdex/compare/v0.12.1...v0.12.2) (2026-04-22)
 

--- a/lib/mdex/document.ex
+++ b/lib/mdex/document.ex
@@ -2180,6 +2180,7 @@ defmodule MDEx.Document do
     case render_existing_nodes(document) do
       {:ok, existing_markdown} ->
         buffer = merge_with_existing(document, existing_markdown)
+        document = clear_pending_html(document)
         flush_buffer(document, buffer)
 
       {:error, halted} ->
@@ -2223,8 +2224,21 @@ defmodule MDEx.Document do
   defp merge_with_existing(%{nodes: nodes, buffer: buffer} = document, existing_markdown) do
     last_node = List.last(nodes)
     state = Document.get_private(document, :fragment_state)
+    buffer = buffer ++ [pending_html(document)]
     MDEx.FragmentParser.merge_stream_buffer(existing_markdown, buffer, last_node, state)
   end
+
+  defp pending_html(%{private: %{fragment_state: %MDEx.FragmentParser.State{pending_html: pending_html}}}) do
+    pending_html || ""
+  end
+
+  defp pending_html(_document), do: ""
+
+  defp clear_pending_html(%{private: %{fragment_state: %MDEx.FragmentParser.State{} = state}} = document) do
+    put_private(document, :fragment_state, %{state | pending_html: nil})
+  end
+
+  defp clear_pending_html(document), do: document
 
   @deprecated "Use MDEx.parse_document/2 or MDEx.Document.put_markdown/1 instead"
   def parse_markdown(%Document{} = document, markdown) when is_binary(markdown) do

--- a/lib/mdex/fragment_parser.ex
+++ b/lib/mdex/fragment_parser.ex
@@ -30,14 +30,15 @@ defmodule MDEx.FragmentParser do
 
   defmodule State do
     @moduledoc false
-    defstruct last_unclosed_token: nil, last_flush_ended_with_newline: true
+    defstruct last_unclosed_token: nil, last_flush_ended_with_newline: true, pending_html: nil
   end
 
   @spec complete_with_state(String.t(), %State{} | nil) :: {String.t(), %State{}}
-  def complete_with_state(fragment, state) do
+  def complete_with_state(raw_fragment, state) do
     state = state || %State{}
     prefix = state.last_unclosed_token || ""
-    completed = complete(fragment, prefix: prefix)
+    fragment = (state.pending_html || "") <> raw_fragment
+    {completed, pending_html} = complete_fragment(fragment, prefix: prefix, preserve_pending_html: true)
 
     # Detect what token we closed (if any) to pass as prefix next time
     new_unclosed = extract_unclosed_token(fragment, prefix)
@@ -45,7 +46,8 @@ defmodule MDEx.FragmentParser do
     new_state = %{
       state
       | last_unclosed_token: new_unclosed,
-        last_flush_ended_with_newline: trailing_newline?(fragment)
+        last_flush_ended_with_newline: trailing_newline?(raw_fragment),
+        pending_html: pending_html
     }
 
     {completed, new_state}
@@ -62,17 +64,22 @@ defmodule MDEx.FragmentParser do
 
   @spec complete(String.t(), keyword()) :: String.t()
   def complete(fragment, options \\ []) do
+    {completed, _pending_html} = complete_fragment(fragment, options)
+    completed
+  end
+
+  defp complete_fragment(fragment, options) do
     prefix = options[:prefix] || ""
 
     if list_marker_line?(fragment) do
       {trailing_ws, core_with_leading} = split_trailing_ws(fragment)
-      {completed, flag} = complete_core(core_with_leading, prefix, trailing_ws, options)
-      completed <> adjust_trailing(trailing_ws, flag)
+      {completed, flag, pending_html} = complete_core(core_with_leading, prefix, trailing_ws, options)
+      {completed <> adjust_trailing(trailing_ws, flag), pending_html}
     else
       {leading, core, trailing} = split_ws(fragment)
       leading = maybe_preserve_leading(leading)
-      {completed, flag} = complete_core(core, prefix, trailing, options)
-      leading <> completed <> adjust_trailing(trailing, flag)
+      {completed, flag, pending_html} = complete_core(core, prefix, trailing, options)
+      {leading <> completed <> adjust_trailing(trailing, flag), pending_html}
     end
   end
 
@@ -118,15 +125,15 @@ defmodule MDEx.FragmentParser do
 
   defp adjust_trailing(trailing, _flag), do: trailing
 
-  defp complete_core("", _prefix, _trailing, _options), do: {"", :none}
+  defp complete_core("", _prefix, _trailing, _options), do: {"", :none, nil}
 
   defp complete_core(core, prefix, trailing, options) do
-    with nil <- maybe_complete_fence(core, trailing, options),
-         nil <- maybe_complete_table(core, trailing),
-         nil <- maybe_complete_math(core, trailing) do
-      line = last_line(core)
+    {completed, flag} =
+      with nil <- maybe_complete_fence(core, trailing, options),
+           nil <- maybe_complete_table(core, trailing),
+           nil <- maybe_complete_math(core, trailing) do
+        line = last_line(core)
 
-      {completed, flag} =
         cond do
           skip_completion?(core, line) ->
             {core, :none}
@@ -167,9 +174,10 @@ defmodule MDEx.FragmentParser do
                 end
             end
         end
+      end
 
-      {strip_incomplete_html(completed), flag}
-    end
+    {completed, pending_html} = strip_incomplete_html(completed, options[:preserve_pending_html] == true)
+    {completed, flag, pending_html}
   end
 
   defp maybe_complete_fence(core, trailing, _options) do
@@ -814,29 +822,32 @@ defmodule MDEx.FragmentParser do
   defp char_type(char) when char in ?a..?z, do: :word
   defp char_type(_char), do: :boundary
 
-  defp strip_incomplete_html(text) do
+  defp strip_incomplete_html(text, preserve_pending_html) do
     case last_byte_pos(text, ?<) do
       nil ->
-        text
+        {text, nil}
 
       pos ->
         after_lt_size = byte_size(text) - pos
 
         if :binary.match(text, ">", [{:scope, {pos, after_lt_size}}]) != :nomatch do
-          text
+          {text, nil}
         else
           after_lt = binary_part(text, pos, after_lt_size)
 
           cond do
+            preserve_pending_html and after_lt == "<" and not inside_inline_code?(text, pos) ->
+              {String.trim_trailing(binary_part(text, 0, pos)), after_lt}
+
             tag_start?(after_lt) ->
               if inside_inline_code?(text, pos) do
-                text
+                {text, nil}
               else
-                String.trim_trailing(binary_part(text, 0, pos))
+                {String.trim_trailing(binary_part(text, 0, pos)), after_lt}
               end
 
             true ->
-              text
+              {text, nil}
           end
         end
     end

--- a/test/mdex/fragment_parser_test.exs
+++ b/test/mdex/fragment_parser_test.exs
@@ -359,6 +359,25 @@ defmodule MDEx.FragmentParserTest do
     test "inline code with < is not stripped" do
       assert complete("`<div`") == "`<div`"
     end
+
+    test "incomplete tag is preserved in state" do
+      assert {"Hello", %MDEx.FragmentParser.State{pending_html: "<div"}} =
+               complete_with_state("Hello <div", nil)
+    end
+
+    test "pending incomplete tag is prepended on next completion" do
+      {_completed, state} = complete_with_state("<div", nil)
+
+      assert {"<div>hello", %MDEx.FragmentParser.State{pending_html: nil}} =
+               complete_with_state(">hello", state)
+    end
+
+    test "trailing bare less-than is preserved only in stateful completion" do
+      assert complete("hello <") == "hello <"
+
+      assert {"hello", %MDEx.FragmentParser.State{pending_html: "<"}} =
+               complete_with_state("hello <", nil)
+    end
   end
 
   describe "nested bracket depth in links" do

--- a/test/mdex/streaming_test.exs
+++ b/test/mdex/streaming_test.exs
@@ -1258,6 +1258,16 @@ defmodule MDEx.StreamingTest do
                )
     end
 
+    test "preserves incomplete html across multiple flushes" do
+      assert [
+               %HtmlBlock{literal: "<div>foo</div>"}
+             ] =
+               multi_flush_nodes(
+                 ["<div", ">foo<", "/div>"],
+                 MDEx.new(streaming: true)
+               )
+    end
+
     test "continues trailing title" do
       assert [
                %Heading{nodes: [%Text{literal: "Title"}]}


### PR DESCRIPTION
Hi! I've been experimenting with MDEx streaming and came across an edge case, where HTML tags in some cases aren't parsed. I reproduced it with the following test:

```elixir
    test "html across multiple flushes" do
      assert [
               %HtmlBlock{literal: "<div>foo\n</div>"}
             ] =
               multi_flush_nodes(
                 ["<div", ">foo<", "/div>"],
                 MDEx.new(streaming: true)
               )
    end
```

Which is failing on main:

```bash
  1) test multi-flush streaming (run between chunks) html across multiple flushes (MDEx.StreamingTest)
     test/mdex/streaming_test.exs:1251
     match (=) failed
     code:  assert [%HtmlBlock{literal: "<div>foo\n</div>"}] =
              multi_flush_nodes(
                ["<div", ">foo<", "/div>"],
                MDEx.new(streaming: true)
              )
     left:  [%MDEx.HtmlBlock{literal: "<div>foo\n</div>"}]
     right: [
              %MDEx.BlockQuote{
                nodes: [%MDEx.Paragraph{nodes: [%MDEx.Text{literal: "foo<", sourcepos: %MDEx.Sourcepos{start: {1, 3}, end: {1, 7}}}, %MDEx.SoftBreak{sourcepos: %MDEx.Sourcepos{start: {1, 8}, end: {1, 8}}}, %MDEx.Text{literal: "/div>", sourcepos: %MDEx.Sourcepos{start: {2, 1}, end: {2, 5}}}], sourcepos: %MDEx.Sourcepos{start: {1, 3}, end: {2, 5}}}],
                sourcepos: %MDEx.Sourcepos{end: {2, 5}, start: {1, 1}}
              }
            ]
     stacktrace:
       test/mdex/streaming_test.exs:1252: (test)
```


From there I used Codex in an attempt to fix it (hope this is ok). I verified this to the best of my abilities, but admittedly MDEx is a complex project to get into from get go! Absolutely feel free to just take the test and throw out the rest.

<details>
<summary>LLM generated description</summary>

## Summary

Fix streaming markdown parsing when incomplete HTML is split across multiple `Document.run/1` flushes.

Previously, incomplete HTML such as `<div` could be stripped before parsing without preserving the stripped fragment. If the next chunk started with `>`, the parser could treat it as standalone Markdown and parse it as a block quote.

## Changes

- Track pending incomplete HTML in `MDEx.FragmentParser.State`.
- Preserve incomplete HTML across `complete_with_state/2` calls.
- Preserve a trailing bare `<` only in stateful streaming completion, allowing split closing tags such as `foo<` + `/div>`.
- Reinsert pending HTML at the correct merge boundary when `Document.run/1` re-renders existing nodes before parsing buffered markdown.
- Add parser-level and streaming regression coverage.
- Add an Unreleased changelog entry.

</details>