### PR TITLE
Fix streaming chunk boundaries without synthetic newlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- [Streaming] Preserve chunk boundaries without synthetic newlines across flushes.
+
 ## [0.12.2](https://github.com/leandrocp/mdex/compare/v0.12.1...v0.12.2) (2026-04-22)
 
 

--- a/lib/mdex/document.ex
+++ b/lib/mdex/document.ex
@@ -2220,9 +2220,10 @@ defmodule MDEx.Document do
     |> IO.iodata_to_binary()
   end
 
-  defp merge_with_existing(%{nodes: nodes, buffer: buffer}, existing_markdown) do
+  defp merge_with_existing(%{nodes: nodes, buffer: buffer} = document, existing_markdown) do
     last_node = List.last(nodes)
-    MDEx.FragmentParser.merge_stream_buffer(existing_markdown, buffer, last_node)
+    state = Document.get_private(document, :fragment_state)
+    MDEx.FragmentParser.merge_stream_buffer(existing_markdown, buffer, last_node, state)
   end
 
   @deprecated "Use MDEx.parse_document/2 or MDEx.Document.put_markdown/1 instead"

--- a/lib/mdex/fragment_parser.ex
+++ b/lib/mdex/fragment_parser.ex
@@ -30,7 +30,7 @@ defmodule MDEx.FragmentParser do
 
   defmodule State do
     @moduledoc false
-    defstruct last_unclosed_token: nil
+    defstruct last_unclosed_token: nil, last_flush_ended_with_newline: true
   end
 
   @spec complete_with_state(String.t(), %State{} | nil) :: {String.t(), %State{}}
@@ -41,8 +41,18 @@ defmodule MDEx.FragmentParser do
 
     # Detect what token we closed (if any) to pass as prefix next time
     new_unclosed = extract_unclosed_token(fragment, prefix)
-    {completed, %State{last_unclosed_token: new_unclosed}}
+
+    new_state = %{
+      state
+      | last_unclosed_token: new_unclosed,
+        last_flush_ended_with_newline: trailing_newline?(fragment)
+    }
+
+    {completed, new_state}
   end
+
+  defp trailing_newline?(<<>>), do: false
+  defp trailing_newline?(binary), do: :binary.last(binary) in [?\n, ?\r]
 
   defp extract_unclosed_token(fragment, prefix) do
     full = if prefix != "", do: prefix <> fragment, else: fragment
@@ -305,10 +315,10 @@ defmodule MDEx.FragmentParser do
   end
 
   @doc false
-  def merge_stream_buffer(existing_markdown, buffer, last_node) do
+  def merge_stream_buffer(existing_markdown, buffer, last_node, state \\ %State{}) do
     existing_markdown
     |> maybe_strip_trailing_fence(last_node)
-    |> ensure_trailing_newline()
+    |> prepare_stream_boundary(state)
     |> append_buffer(buffer)
   end
 
@@ -319,12 +329,26 @@ defmodule MDEx.FragmentParser do
 
   defp maybe_strip_trailing_fence(markdown, _), do: markdown
 
+  defp prepare_stream_boundary(markdown, %State{last_flush_ended_with_newline: false}) do
+    trim_trailing_newline(markdown)
+  end
+
+  defp prepare_stream_boundary(markdown, _state), do: ensure_trailing_newline(markdown)
+
   defp ensure_trailing_newline(<<>>), do: ""
 
   defp ensure_trailing_newline(binary) do
     case :binary.last(binary) do
       ?\n -> binary
       _ -> binary <> "\n"
+    end
+  end
+
+  defp trim_trailing_newline(binary) do
+    cond do
+      String.ends_with?(binary, "\r\n") -> binary_part(binary, 0, byte_size(binary) - 2)
+      String.ends_with?(binary, "\n") -> binary_part(binary, 0, byte_size(binary) - 1)
+      true -> binary
     end
   end
 

--- a/test/mdex/streaming_test.exs
+++ b/test/mdex/streaming_test.exs
@@ -6,6 +6,7 @@ defmodule MDEx.StreamingTest do
   alias MDEx.CodeBlock
   alias MDEx.Emph
   alias MDEx.Heading
+  alias MDEx.HtmlBlock
   # alias MDEx.Image
   # alias MDEx.Link
   alias MDEx.List
@@ -1245,6 +1246,26 @@ defmodule MDEx.StreamingTest do
 
       assert text =~ "Hello"
       assert text =~ "world"
+    end
+
+    test "continues trailing html block without injecting a newline" do
+      assert [
+               %HtmlBlock{literal: "<div>foobar</div>"}
+             ] =
+               multi_flush_nodes(
+                 ["<div>foo", "bar</div>"],
+                 MDEx.new(streaming: true)
+               )
+    end
+
+    test "continues trailing title" do
+      assert [
+               %Heading{nodes: [%Text{literal: "Title"}]}
+             ] =
+               multi_flush_nodes(
+                 ["# Tit", "le"],
+                 MDEx.new(streaming: true)
+               )
     end
   end
 end


### PR DESCRIPTION
Hi @leandrocp 👋 

Consider following test for streaming parsing:

```elixir
    test "continues trailing title" do
      assert [
               %Heading{nodes: [%Text{literal: "Title"}]}
             ] =
               multi_flush_nodes(
                 ["# Tit", "le"],
                 MDEx.new(streaming: true)
               )
    end
```

```
  1) test multi-flush streaming (run between chunks) continues trailing title (MDEx.StreamingTest)
     test/mdex/streaming_test.exs:1250
     match (=) failed
     code:  assert [%Heading{nodes: [%Text{literal: "Title"}]}] =
              multi_flush_nodes(
                ["# Tit", "le"],
                MDEx.new(streaming: true)
              )
     left:  [%MDEx.Heading{nodes: [%MDEx.Text{literal: "Title"}]}]
     right: [
              %MDEx.Heading{
                nodes: [%MDEx.Text{literal: "Tit", sourcepos: %MDEx.Sourcepos{end: {1, 5}, start: {1, 3}}}],
                closed: false,
                level: 1,
                setext: false,
                sourcepos: %MDEx.Sourcepos{end: {1, 5}, start: {1, 1}}
              },
              %MDEx.Paragraph{
                nodes: [%MDEx.Text{literal: "le", sourcepos: %MDEx.Sourcepos{start: {2, 1}, end: {2, 2}}}],
                sourcepos: %MDEx.Sourcepos{end: {2, 2}, start: {2, 1}}
              }
            ]
     stacktrace:
       test/mdex/streaming_test.exs:1251: (test)


Finished in 0.2 seconds (0.2s async, 0.00s sync)
```

As you can see MDEx parses two chunks of a header as two header elements. This is happening due to the way streaming is implemented: for each received chunk, MDEx reconstructs underlying raw document by dumping nodes into formatted markdown document before appending new chunk and reparsing. Inevitably, formatter puts a trailing newline, even if "true" document did not have it. As a result what is being parsed on second flush is not `# Title`, but actually `# Tit\nle`. 

This PR aims to fix this by adding a flag to the parser state which whole purpose is to remember if initial raw buffer we parsed so far had a trailing newline. And if it didn't, we trim it from the reconstructed document before passing to comrak.

<details>
<summary>
This is an LLM-assisted PR. See original LLM generated description of changes
</summary>

## Summary

Fix multi-flush streaming so MDEx preserves chunk boundaries instead of treating formatter-added trailing newlines as original input.

Previously, when `Document.run/1` was called between chunks, MDEx rendered the existing document back to Markdown before appending the next chunk. That render step could add a trailing newline, causing split content like `["# Tit", "le"]` or `["<div>foo", "bar</div>"]` to be reparsed with an unintended newline.

## Changes

- Track whether the last raw streaming fragment ended with a newline in `MDEx.FragmentParser.State`.
- Let `FragmentParser.complete_with_state/2` compute and store that state from the raw fragment.
- Pass parser state into `merge_stream_buffer/4` so it can trim one synthetic rendered newline when the original stream did not contain one.
- Add regression coverage for split headings and streamed HTML blocks.
- Add an Unreleased changelog entry.

</details>