### PR TITLE
feat: add Slack mrkdwn converter (to_slack/2)

### DIFF
--- a/lib/mdex.ex
+++ b/lib/mdex.ex
@@ -37,6 +37,7 @@ defmodule MDEx do
   alias MDEx.Document
   alias MDEx.DecodeError
   alias MDEx.InvalidInputError
+  alias MDEx.SlackConverter
   alias MDExNative.Comrak
 
   import MDEx.Document, only: [is_fragment: 1]
@@ -913,6 +914,95 @@ defmodule MDEx do
   @spec to_delta!(source(), keyword()) :: [map()]
   def to_delta!(source, options \\ []) do
     case to_delta(source, options) do
+      {:ok, result} -> result
+      {:error, error} -> raise error
+    end
+  end
+
+  @doc """
+  Convert Markdown or `MDEx.Document` to Slack mrkdwn format.
+
+  Slack uses its own mrkdwn dialect that differs from CommonMark:
+  bold uses `*text*`, italic uses `_text_`, links use `<url|label>`,
+  and headings are not supported (rendered as bold text).
+
+  ## Examples
+
+      iex> MDEx.to_slack("**Hello** _world_")
+      {:ok, "*Hello* _world_\\n"}
+
+      iex> MDEx.to_slack("# Title\\n[link](https://example.com)")
+      {:ok, "*Title*\\n<https://example.com|link>\\n"}
+
+  ## Options
+
+    * `t:MDEx.Document.options/0` - options passed to the parser and document processing
+    * `:custom_converters` - map of node types to converter functions for custom behavior
+
+  ## Custom Converters
+
+  Custom converters allow you to override the default behavior for any node type.
+  The converter function receives `(node, options)` and must return a binary string,
+  `:skip` to skip the node, or `{:error, reason}` to signal an error.
+
+  """
+  @spec to_slack(source(), keyword()) ::
+          {:ok, String.t()} | {:error, MDEx.DecodeError.t()} | {:error, MDEx.InvalidInputError.t()}
+  def to_slack(source, options \\ [])
+
+  def to_slack(source, options) when is_binary(source) and is_list(options) do
+    {_deprecated_document, options} = pop_deprecated_document_option(options)
+
+    parse_options = Keyword.drop(options, [:custom_converters])
+
+    with {:ok, document} <- parse_document(source, parse_options) do
+      to_slack(document, options)
+    end
+  end
+
+  def to_slack(%Document{} = document, options) when is_list(options) do
+    {document_opt, options} = pop_deprecated_document_option(options)
+
+    validated_options =
+      options
+      |> Keyword.take([:custom_converters])
+      |> NimbleOptions.validate!(custom_converters: [type: :map, default: %{}])
+
+    document_options = Keyword.drop(options, [:custom_converters])
+
+    document
+    |> Document.put_options(document_options)
+    |> maybe_apply_document_option(document_opt)
+    |> Document.run()
+    |> then(fn document ->
+      document
+      |> SlackConverter.convert(validated_options)
+      |> case do
+        {:ok, text} ->
+          {:ok, text}
+
+        {:error, reason} ->
+          {:error, %DecodeError{document: document, error: reason}}
+      end
+    end)
+  end
+
+  def to_slack(source, options) do
+    if is_fragment(source) do
+      source
+      |> Document.wrap()
+      |> to_slack(options)
+    else
+      {:error, %InvalidInputError{found: source}}
+    end
+  end
+
+  @doc """
+  Same as `to_slack/2` but raises on error.
+  """
+  @spec to_slack!(source(), keyword()) :: String.t()
+  def to_slack!(source, options \\ []) do
+    case to_slack(source, options) do
       {:ok, result} -> result
       {:error, error} -> raise error
     end

--- a/lib/mdex.ex
+++ b/lib/mdex.ex
@@ -955,6 +955,12 @@ defmodule MDEx do
 
     parse_options = Keyword.drop(options, [:custom_converters])
 
+    # Slack mrkdwn renders strikethrough as ~text~, so enable the GFM
+    # strikethrough extension by default when parsing. A caller can still
+    # disable it explicitly via `extension: [strikethrough: false]`.
+    extension = Keyword.merge([strikethrough: true], parse_options[:extension] || [])
+    parse_options = Keyword.put(parse_options, :extension, extension)
+
     with {:ok, document} <- parse_document(source, parse_options) do
       to_slack(document, options)
     end

--- a/lib/mdex/slack_converter.ex
+++ b/lib/mdex/slack_converter.ex
@@ -1,0 +1,234 @@
+defmodule MDEx.SlackConverter do
+  @moduledoc false
+
+  alias MDEx.Document
+
+  @typedoc "Conversion options"
+  @type options :: keyword()
+
+  @doc """
+  Convert an MDEx document to Slack mrkdwn format.
+
+  ## Examples
+
+      iex> doc = %MDEx.Document{nodes: [%MDEx.Text{literal: "Hello"}]}
+      iex> MDEx.SlackConverter.convert(doc, [])
+      {:ok, "Hello"}
+
+  """
+  @spec convert(Document.t(), options()) :: {:ok, String.t()} | {:error, term()}
+  def convert(%Document{nodes: nodes}, options) do
+    try do
+      result = convert_nodes(nodes, options)
+      {:ok, result}
+    rescue
+      error -> {:error, error}
+    catch
+      error -> {:error, error}
+    end
+  end
+
+  @spec convert_nodes([term()], options()) :: String.t()
+  defp convert_nodes(nodes, options) do
+    Enum.map_join(nodes, "", fn node -> convert_node(node, options) end)
+  end
+
+  @spec convert_node(term(), options()) :: String.t()
+  defp convert_node(node, options) do
+    custom_converters = Keyword.get(options, :custom_converters, %{})
+
+    case Map.get(custom_converters, node.__struct__) do
+      converter when is_function(converter, 2) ->
+        case converter.(node, options) do
+          :skip -> ""
+          {:error, reason} -> throw({:custom_converter_error, reason})
+          text when is_binary(text) -> text
+          other -> throw({:custom_converter_error, "Custom converter returned invalid value: #{inspect(other)}"})
+        end
+
+      nil ->
+        default_convert_node(node, options)
+    end
+  end
+
+  @spec default_convert_node(term(), options()) :: String.t()
+  defp default_convert_node(node, options)
+
+  # Document
+  defp default_convert_node(%MDEx.Document{nodes: nodes}, options) do
+    convert_nodes(nodes, options)
+  end
+
+  # Paragraph
+  defp default_convert_node(%MDEx.Paragraph{nodes: nodes}, options) do
+    convert_nodes(nodes, options) <> "\n"
+  end
+
+  # Text
+  defp default_convert_node(%MDEx.Text{literal: text}, _options) do
+    text
+  end
+
+  # Strong (bold) -> *text*
+  defp default_convert_node(%MDEx.Strong{nodes: nodes}, options) do
+    "*" <> convert_nodes(nodes, options) <> "*"
+  end
+
+  # Emph (italic) -> _text_
+  defp default_convert_node(%MDEx.Emph{nodes: nodes}, options) do
+    "_" <> convert_nodes(nodes, options) <> "_"
+  end
+
+  # Inline code -> `code`
+  defp default_convert_node(%MDEx.Code{literal: code}, _options) do
+    "`" <> code <> "`"
+  end
+
+  # Code block -> triple backtick, no language tag
+  defp default_convert_node(%MDEx.CodeBlock{literal: code}, _options) do
+    "```\n" <> String.trim_trailing(code, "\n") <> "\n```\n"
+  end
+
+  # Headings -> *bold text* (Slack ignores # headings)
+  defp default_convert_node(%MDEx.Heading{nodes: nodes}, options) do
+    "*" <> convert_nodes(nodes, options) <> "*\n"
+  end
+
+  # Link -> <url|label>
+  defp default_convert_node(%MDEx.Link{url: url, nodes: nodes}, options) do
+    label = convert_nodes(nodes, options)
+    "<" <> url <> "|" <> label <> ">"
+  end
+
+  # Strikethrough -> ~text~
+  defp default_convert_node(%MDEx.Strikethrough{nodes: nodes}, options) do
+    "~" <> convert_nodes(nodes, options) <> "~"
+  end
+
+  # BlockQuote -> > text
+  defp default_convert_node(%MDEx.BlockQuote{nodes: nodes}, options) do
+    inner = convert_nodes(nodes, options)
+
+    inner
+    |> String.split("\n")
+    |> Enum.map_join("\n", fn
+      "" -> ""
+      line -> "> " <> line
+    end)
+  end
+
+  # Unordered list
+  defp default_convert_node(%MDEx.List{list_type: :bullet, nodes: items}, options) do
+    convert_nodes(items, options)
+  end
+
+  # Ordered list
+  defp default_convert_node(%MDEx.List{list_type: :ordered, tight: _tight, nodes: items}, options) do
+    items
+    |> Enum.with_index(1)
+    |> Enum.map_join("", fn {item, index} ->
+      convert_list_item(item, "#{index}. ", options)
+    end)
+  end
+
+  # Generic list fallback
+  defp default_convert_node(%MDEx.List{nodes: items}, options) do
+    convert_nodes(items, options)
+  end
+
+  # ListItem for bullet lists
+  defp default_convert_node(%MDEx.ListItem{list_type: :bullet, nodes: children}, options) do
+    convert_list_item(%MDEx.ListItem{nodes: children}, "- ", options)
+  end
+
+  # ListItem for ordered lists (index unknown at this level; handled by List above)
+  defp default_convert_node(%MDEx.ListItem{nodes: children}, options) do
+    convert_list_item(%MDEx.ListItem{nodes: children}, "- ", options)
+  end
+
+  # SoftBreak -> space
+  defp default_convert_node(%MDEx.SoftBreak{}, _options) do
+    " "
+  end
+
+  # LineBreak -> newline
+  defp default_convert_node(%MDEx.LineBreak{}, _options) do
+    "\n"
+  end
+
+  # ThematicBreak -> horizontal separator text
+  defp default_convert_node(%MDEx.ThematicBreak{}, _options) do
+    "---\n"
+  end
+
+  # Image -> <url|alt>
+  defp default_convert_node(%MDEx.Image{url: url, title: title}, _options) do
+    label = if title && title != "", do: title, else: url
+    "<" <> url <> "|" <> label <> ">"
+  end
+
+  # HtmlBlock and HtmlInline -> strip tags, pass through text
+  defp default_convert_node(%MDEx.HtmlBlock{literal: html}, _options) do
+    strip_html(html) <> "\n"
+  end
+
+  defp default_convert_node(%MDEx.HtmlInline{literal: html}, _options) do
+    strip_html(html)
+  end
+
+  # Raw -> pass through
+  defp default_convert_node(%MDEx.Raw{literal: content}, _options) do
+    content
+  end
+
+  # ShortCode (emoji)
+  defp default_convert_node(%MDEx.ShortCode{emoji: emoji}, _options) do
+    emoji
+  end
+
+  # FrontMatter -> skip
+  defp default_convert_node(%MDEx.FrontMatter{}, _options) do
+    ""
+  end
+
+  # Fallback for unknown node types
+  defp default_convert_node(node, options) do
+    cond do
+      is_map(node) && Map.has_key?(node, :literal) && is_binary(node.literal) ->
+        node.literal
+
+      is_map(node) && Map.has_key?(node, :nodes) && is_list(node.nodes) ->
+        convert_nodes(node.nodes, options)
+
+      true ->
+        ""
+    end
+  end
+
+  # Helper: convert a ListItem, prepending the given prefix
+  defp convert_list_item(%{nodes: children}, prefix, options) do
+    # Extract text content from paragraphs and nested lists
+    {paragraph_nodes, nested_lists} =
+      Enum.split_with(children, fn node -> not match?(%MDEx.List{}, node) end)
+
+    text =
+      Enum.map_join(paragraph_nodes, "", fn
+        %MDEx.Paragraph{nodes: p_nodes} -> convert_nodes(p_nodes, options)
+        node -> convert_node(node, options)
+      end)
+
+    item_line = prefix <> text <> "\n"
+
+    nested =
+      Enum.map_join(nested_lists, "", fn nested_list ->
+        convert_node(nested_list, options)
+      end)
+
+    item_line <> nested
+  end
+
+  # Helper: strip HTML tags
+  defp strip_html(html) do
+    Regex.replace(~r/<[^>]+>/, html, "")
+  end
+end

--- a/lib/mdex/slack_converter.ex
+++ b/lib/mdex/slack_converter.ex
@@ -5,6 +5,7 @@ defmodule MDEx.SlackConverter do
 
   @typedoc "Conversion options"
   @type options :: keyword()
+  @typep conversion_result :: {:ok, String.t()} | {:error, term()}
 
   @doc """
   Convert an MDEx document to Slack mrkdwn format.
@@ -18,32 +19,26 @@ defmodule MDEx.SlackConverter do
   """
   @spec convert(Document.t(), options()) :: {:ok, String.t()} | {:error, term()}
   def convert(%Document{nodes: nodes}, options) do
-    try do
-      result = convert_nodes(nodes, options)
-      {:ok, result}
-    rescue
-      error -> {:error, error}
-    catch
-      error -> {:error, error}
-    end
+    convert_nodes(nodes, options)
   end
 
-  @spec convert_nodes([term()], options()) :: String.t()
+  @spec convert_nodes([term()], options()) :: conversion_result()
   defp convert_nodes(nodes, options) do
-    Enum.map_join(nodes, "", fn node -> convert_node(node, options) end)
+    reduce_text(nodes, fn node -> convert_node(node, options) end)
   end
 
-  @spec convert_node(term(), options()) :: String.t()
+  @spec convert_node(term(), options()) :: conversion_result()
   defp convert_node(node, options) do
     custom_converters = Keyword.get(options, :custom_converters, %{})
+    node_type = if is_map(node), do: Map.get(node, :__struct__)
 
-    case Map.get(custom_converters, node.__struct__) do
+    case Map.get(custom_converters, node_type) do
       converter when is_function(converter, 2) ->
         case converter.(node, options) do
-          :skip -> ""
-          {:error, reason} -> throw({:custom_converter_error, reason})
-          text when is_binary(text) -> text
-          other -> throw({:custom_converter_error, "Custom converter returned invalid value: #{inspect(other)}"})
+          :skip -> {:ok, ""}
+          {:error, reason} -> {:error, {:custom_converter_error, reason}}
+          text when is_binary(text) -> {:ok, text}
+          other -> {:error, {:custom_converter_error, "Custom converter returned invalid value: #{inspect(other)}"}}
         end
 
       nil ->
@@ -51,7 +46,22 @@ defmodule MDEx.SlackConverter do
     end
   end
 
-  @spec default_convert_node(term(), options()) :: String.t()
+  @spec reduce_text(Enumerable.t(), (term() -> conversion_result())) :: conversion_result()
+  defp reduce_text(items, converter) do
+    items
+    |> Enum.reduce_while([], fn item, acc ->
+      case converter.(item) do
+        {:ok, text} -> {:cont, [text | acc]}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+    |> case do
+      {:error, _reason} = error -> error
+      parts -> {:ok, parts |> Enum.reverse() |> IO.iodata_to_binary()}
+    end
+  end
+
+  @spec default_convert_node(term(), options()) :: conversion_result()
   defp default_convert_node(node, options)
 
   # Document
@@ -61,60 +71,74 @@ defmodule MDEx.SlackConverter do
 
   # Paragraph
   defp default_convert_node(%MDEx.Paragraph{nodes: nodes}, options) do
-    convert_nodes(nodes, options) <> "\n"
+    with {:ok, text} <- convert_nodes(nodes, options) do
+      {:ok, text <> "\n"}
+    end
   end
 
   # Text
   defp default_convert_node(%MDEx.Text{literal: text}, _options) do
-    text
+    {:ok, text}
   end
 
   # Strong (bold) -> *text*
   defp default_convert_node(%MDEx.Strong{nodes: nodes}, options) do
-    "*" <> convert_nodes(nodes, options) <> "*"
+    with {:ok, text} <- convert_nodes(nodes, options) do
+      {:ok, "*" <> text <> "*"}
+    end
   end
 
   # Emph (italic) -> _text_
   defp default_convert_node(%MDEx.Emph{nodes: nodes}, options) do
-    "_" <> convert_nodes(nodes, options) <> "_"
+    with {:ok, text} <- convert_nodes(nodes, options) do
+      {:ok, "_" <> text <> "_"}
+    end
   end
 
   # Inline code -> `code`
   defp default_convert_node(%MDEx.Code{literal: code}, _options) do
-    "`" <> code <> "`"
+    {:ok, "`" <> code <> "`"}
   end
 
   # Code block -> triple backtick, no language tag
   defp default_convert_node(%MDEx.CodeBlock{literal: code}, _options) do
-    "```\n" <> String.trim_trailing(code, "\n") <> "\n```\n"
+    {:ok, "```\n" <> String.trim_trailing(code, "\n") <> "\n```\n"}
   end
 
   # Headings -> *bold text* (Slack ignores # headings)
   defp default_convert_node(%MDEx.Heading{nodes: nodes}, options) do
-    "*" <> convert_nodes(nodes, options) <> "*\n"
+    with {:ok, text} <- convert_nodes(nodes, options) do
+      {:ok, "*" <> text <> "*\n"}
+    end
   end
 
   # Link -> <url|label>
   defp default_convert_node(%MDEx.Link{url: url, nodes: nodes}, options) do
-    label = convert_nodes(nodes, options)
-    "<" <> url <> "|" <> label <> ">"
+    with {:ok, label} <- convert_nodes(nodes, options) do
+      {:ok, "<" <> url <> "|" <> label <> ">"}
+    end
   end
 
   # Strikethrough -> ~text~
   defp default_convert_node(%MDEx.Strikethrough{nodes: nodes}, options) do
-    "~" <> convert_nodes(nodes, options) <> "~"
+    with {:ok, text} <- convert_nodes(nodes, options) do
+      {:ok, "~" <> text <> "~"}
+    end
   end
 
   # BlockQuote -> > text
   defp default_convert_node(%MDEx.BlockQuote{nodes: nodes}, options) do
-    inner = convert_nodes(nodes, options)
+    with {:ok, inner} <- convert_nodes(nodes, options) do
+      text =
+        inner
+        |> String.split("\n")
+        |> Enum.map_join("\n", fn
+          "" -> ""
+          line -> "> " <> line
+        end)
 
-    inner
-    |> String.split("\n")
-    |> Enum.map_join("\n", fn
-      "" -> ""
-      line -> "> " <> line
-    end)
+      {:ok, text}
+    end
   end
 
   # Unordered list
@@ -126,9 +150,7 @@ defmodule MDEx.SlackConverter do
   defp default_convert_node(%MDEx.List{list_type: :ordered, tight: _tight, nodes: items}, options) do
     items
     |> Enum.with_index(1)
-    |> Enum.map_join("", fn {item, index} ->
-      convert_list_item(item, "#{index}. ", options)
-    end)
+    |> reduce_text(fn {item, index} -> convert_list_item(item, "#{index}. ", options) end)
   end
 
   # Generic list fallback
@@ -148,60 +170,60 @@ defmodule MDEx.SlackConverter do
 
   # SoftBreak -> space
   defp default_convert_node(%MDEx.SoftBreak{}, _options) do
-    " "
+    {:ok, " "}
   end
 
   # LineBreak -> newline
   defp default_convert_node(%MDEx.LineBreak{}, _options) do
-    "\n"
+    {:ok, "\n"}
   end
 
   # ThematicBreak -> horizontal separator text
   defp default_convert_node(%MDEx.ThematicBreak{}, _options) do
-    "---\n"
+    {:ok, "---\n"}
   end
 
   # Image -> <url|alt>
   defp default_convert_node(%MDEx.Image{url: url, title: title}, _options) do
     label = if title && title != "", do: title, else: url
-    "<" <> url <> "|" <> label <> ">"
+    {:ok, "<" <> url <> "|" <> label <> ">"}
   end
 
   # HtmlBlock and HtmlInline -> strip tags, pass through text
   defp default_convert_node(%MDEx.HtmlBlock{literal: html}, _options) do
-    strip_html(html) <> "\n"
+    {:ok, strip_html(html) <> "\n"}
   end
 
   defp default_convert_node(%MDEx.HtmlInline{literal: html}, _options) do
-    strip_html(html)
+    {:ok, strip_html(html)}
   end
 
   # Raw -> pass through
   defp default_convert_node(%MDEx.Raw{literal: content}, _options) do
-    content
+    {:ok, content}
   end
 
   # ShortCode (emoji)
   defp default_convert_node(%MDEx.ShortCode{emoji: emoji}, _options) do
-    emoji
+    {:ok, emoji}
   end
 
   # FrontMatter -> skip
   defp default_convert_node(%MDEx.FrontMatter{}, _options) do
-    ""
+    {:ok, ""}
   end
 
   # Fallback for unknown node types
   defp default_convert_node(node, options) do
     cond do
       is_map(node) && Map.has_key?(node, :literal) && is_binary(node.literal) ->
-        node.literal
+        {:ok, node.literal}
 
       is_map(node) && Map.has_key?(node, :nodes) && is_list(node.nodes) ->
         convert_nodes(node.nodes, options)
 
       true ->
-        ""
+        {:ok, ""}
     end
   end
 
@@ -211,20 +233,14 @@ defmodule MDEx.SlackConverter do
     {paragraph_nodes, nested_lists} =
       Enum.split_with(children, fn node -> not match?(%MDEx.List{}, node) end)
 
-    text =
-      Enum.map_join(paragraph_nodes, "", fn
-        %MDEx.Paragraph{nodes: p_nodes} -> convert_nodes(p_nodes, options)
-        node -> convert_node(node, options)
-      end)
-
-    item_line = prefix <> text <> "\n"
-
-    nested =
-      Enum.map_join(nested_lists, "", fn nested_list ->
-        convert_node(nested_list, options)
-      end)
-
-    item_line <> nested
+    with {:ok, text} <-
+           reduce_text(paragraph_nodes, fn
+             %MDEx.Paragraph{nodes: p_nodes} -> convert_nodes(p_nodes, options)
+             node -> convert_node(node, options)
+           end),
+         {:ok, nested} <- convert_nodes(nested_lists, options) do
+      {:ok, prefix <> text <> "\n" <> nested}
+    end
   end
 
   # Helper: strip HTML tags

--- a/test/mdex/slack_converter_test.exs
+++ b/test/mdex/slack_converter_test.exs
@@ -1,0 +1,265 @@
+defmodule MDEx.SlackConverterTest do
+  use ExUnit.Case
+
+  alias MDEx.SlackConverter
+  alias MDEx.Document
+
+  describe "convert/2" do
+    test "converts empty document" do
+      input = %Document{nodes: []}
+
+      {:ok, result} = SlackConverter.convert(input, [])
+
+      assert result == ""
+    end
+
+    test "converts plain text paragraph" do
+      input = %Document{nodes: [%MDEx.Paragraph{nodes: [%MDEx.Text{literal: "Hello World"}]}]}
+
+      {:ok, result} = SlackConverter.convert(input, [])
+
+      assert result == "Hello World\n"
+    end
+
+    test "bold becomes *text*" do
+      input = %Document{
+        nodes: [
+          %MDEx.Paragraph{
+            nodes: [%MDEx.Strong{nodes: [%MDEx.Text{literal: "bold"}]}]
+          }
+        ]
+      }
+
+      {:ok, result} = SlackConverter.convert(input, [])
+
+      assert result == "*bold*\n"
+    end
+
+    test "italic becomes _text_" do
+      input = %Document{
+        nodes: [
+          %MDEx.Paragraph{
+            nodes: [%MDEx.Emph{nodes: [%MDEx.Text{literal: "italic"}]}]
+          }
+        ]
+      }
+
+      {:ok, result} = SlackConverter.convert(input, [])
+
+      assert result == "_italic_\n"
+    end
+
+    test "inline code becomes `code`" do
+      input = %Document{
+        nodes: [
+          %MDEx.Paragraph{
+            nodes: [%MDEx.Code{literal: "myFunc()", num_backticks: 1}]
+          }
+        ]
+      }
+
+      {:ok, result} = SlackConverter.convert(input, [])
+
+      assert result == "`myFunc()`\n"
+    end
+
+    test "code block becomes triple-backtick block without language tag" do
+      input = %Document{
+        nodes: [%MDEx.CodeBlock{literal: "def hello do\n  :world\nend\n", info: "elixir", fenced: true, fence_char: "`", fence_length: 3, fence_offset: 0}]
+      }
+
+      {:ok, result} = SlackConverter.convert(input, [])
+
+      assert result == "```\ndef hello do\n  :world\nend\n```\n"
+    end
+
+    test "link becomes <url|label>" do
+      input = %Document{
+        nodes: [
+          %MDEx.Paragraph{
+            nodes: [%MDEx.Link{url: "https://example.com", title: "", nodes: [%MDEx.Text{literal: "Example"}]}]
+          }
+        ]
+      }
+
+      {:ok, result} = SlackConverter.convert(input, [])
+
+      assert result == "<https://example.com|Example>\n"
+    end
+
+    test "strikethrough becomes ~text~" do
+      input = %Document{
+        nodes: [
+          %MDEx.Paragraph{
+            nodes: [%MDEx.Strikethrough{nodes: [%MDEx.Text{literal: "deleted"}]}]
+          }
+        ]
+      }
+
+      {:ok, result} = SlackConverter.convert(input, [])
+
+      assert result == "~deleted~\n"
+    end
+
+    test "unordered list items get - prefix" do
+      input = %Document{
+        nodes: [
+          %MDEx.List{
+            list_type: :bullet,
+            tight: true,
+            nodes: [
+              %MDEx.ListItem{list_type: :bullet, nodes: [%MDEx.Paragraph{nodes: [%MDEx.Text{literal: "first"}]}]},
+              %MDEx.ListItem{list_type: :bullet, nodes: [%MDEx.Paragraph{nodes: [%MDEx.Text{literal: "second"}]}]}
+            ]
+          }
+        ]
+      }
+
+      {:ok, result} = SlackConverter.convert(input, [])
+
+      assert result == "- first\n- second\n"
+    end
+
+    test "ordered list items get numbered prefix" do
+      input = %Document{
+        nodes: [
+          %MDEx.List{
+            list_type: :ordered,
+            tight: true,
+            nodes: [
+              %MDEx.ListItem{list_type: :ordered, nodes: [%MDEx.Paragraph{nodes: [%MDEx.Text{literal: "alpha"}]}]},
+              %MDEx.ListItem{list_type: :ordered, nodes: [%MDEx.Paragraph{nodes: [%MDEx.Text{literal: "beta"}]}]}
+            ]
+          }
+        ]
+      }
+
+      {:ok, result} = SlackConverter.convert(input, [])
+
+      assert result == "1. alpha\n2. beta\n"
+    end
+
+    test "heading levels 1-6 render as *bold text*" do
+      for level <- 1..6 do
+        input = %Document{
+          nodes: [%MDEx.Heading{level: level, setext: false, nodes: [%MDEx.Text{literal: "Title"}]}]
+        }
+
+        {:ok, result} = SlackConverter.convert(input, [])
+
+        assert result == "*Title*\n", "Heading level #{level} failed"
+      end
+    end
+
+    test "blockquote renders as > text" do
+      input = %Document{
+        nodes: [
+          %MDEx.BlockQuote{
+            nodes: [%MDEx.Paragraph{nodes: [%MDEx.Text{literal: "quoted text"}]}]
+          }
+        ]
+      }
+
+      {:ok, result} = SlackConverter.convert(input, [])
+
+      assert result =~ "> quoted text"
+    end
+
+    test "nested inline formatting bold+italic produces *_text_*" do
+      input = %Document{
+        nodes: [
+          %MDEx.Paragraph{
+            nodes: [
+              %MDEx.Strong{
+                nodes: [%MDEx.Emph{nodes: [%MDEx.Text{literal: "nested"}]}]
+              }
+            ]
+          }
+        ]
+      }
+
+      {:ok, result} = SlackConverter.convert(input, [])
+
+      assert result == "*_nested_*\n"
+    end
+
+    test "custom converter override via :custom_converters option" do
+      custom = %{
+        MDEx.Strong => fn _node, _opts -> "CUSTOM_BOLD" end
+      }
+
+      input = %Document{
+        nodes: [
+          %MDEx.Paragraph{
+            nodes: [%MDEx.Strong{nodes: [%MDEx.Text{literal: "text"}]}]
+          }
+        ]
+      }
+
+      {:ok, result} = SlackConverter.convert(input, custom_converters: custom)
+
+      assert result == "CUSTOM_BOLD\n"
+    end
+
+    test "custom converter can skip a node with :skip" do
+      custom = %{
+        MDEx.Strikethrough => fn _node, _opts -> :skip end
+      }
+
+      input = %Document{
+        nodes: [
+          %MDEx.Paragraph{
+            nodes: [
+              %MDEx.Text{literal: "before"},
+              %MDEx.Strikethrough{nodes: [%MDEx.Text{literal: "skipped"}]},
+              %MDEx.Text{literal: "after"}
+            ]
+          }
+        ]
+      }
+
+      {:ok, result} = SlackConverter.convert(input, custom_converters: custom)
+
+      assert result == "beforeafter\n"
+    end
+  end
+
+  describe "to_slack/2 integration" do
+    test "converts markdown string end-to-end" do
+      {:ok, result} = MDEx.to_slack("**bold** and _italic_")
+
+      assert result == "*bold* and _italic_\n"
+    end
+
+    test "to_slack!/2 returns string on success" do
+      result = MDEx.to_slack!("Hello")
+
+      assert is_binary(result)
+      assert result == "Hello\n"
+    end
+
+    test "converts heading from markdown" do
+      {:ok, result} = MDEx.to_slack("# My Heading")
+
+      assert result == "*My Heading*\n"
+    end
+
+    test "converts link from markdown" do
+      {:ok, result} = MDEx.to_slack("[click here](https://example.com)")
+
+      assert result == "<https://example.com|click here>\n"
+    end
+
+    test "converts fenced code block without language tag" do
+      {:ok, result} = MDEx.to_slack("```elixir\nIO.puts(\"hello\")\n```")
+
+      assert result == "```\nIO.puts(\"hello\")\n```\n"
+    end
+
+    test "converts strikethrough from markdown" do
+      {:ok, result} = MDEx.to_slack("~~strikethrough~~")
+
+      assert result == "~strikethrough~\n"
+    end
+  end
+end

--- a/test/mdex/slack_converter_test.exs
+++ b/test/mdex/slack_converter_test.exs
@@ -65,7 +65,9 @@ defmodule MDEx.SlackConverterTest do
 
     test "code block becomes triple-backtick block without language tag" do
       input = %Document{
-        nodes: [%MDEx.CodeBlock{literal: "def hello do\n  :world\nend\n", info: "elixir", fenced: true, fence_char: "`", fence_length: 3, fence_offset: 0}]
+        nodes: [
+          %MDEx.CodeBlock{literal: "def hello do\n  :world\nend\n", info: "elixir", fenced: true, fence_char: "`", fence_length: 3, fence_offset: 0}
+        ]
       }
 
       {:ok, result} = SlackConverter.convert(input, [])


### PR DESCRIPTION
## Summary

Adds `MDEx.SlackConverter`, a new converter that transforms a parsed `MDEx.Document` AST into Slack mrkdwn format. Exposes `MDEx.to_slack/2` and `MDEx.to_slack!/2` as the public API entry points.

## Why this matters

Closes #333 — Elixir applications that pipe LLM-generated Markdown to Slack's API need a safe conversion layer. CommonMark doesn't map directly to Slack mrkdwn: bold is `*text*`, italic is `_text_`, links are `<url|label>`, headings become bold text, and code blocks must drop the language tag. Without this converter, apps either strip all formatting or send raw Markdown that Slack renders incorrectly or rejects.

## Changes

- **`lib/mdex/slack_converter.ex`** — new `MDEx.SlackConverter` module modeled exactly on `MDEx.DeltaConverter`: a single public `convert/2` function accepting `MDEx.Document` + options, with `convert_node/2` helpers covering bold (`*`), italic (`_`), inline code (`` ` ``), fenced code blocks (triple backtick, no language tag), links (`<url|label>`), strikethrough (`~`), headings as bold, blockquotes (`> `), bullet lists (`- `), ordered lists (`1. `), and a `:custom_converters` escape hatch matching the Delta API.
- **`lib/mdex.ex`** — adds `to_slack/2` and `to_slack!/2` following the identical shape as `to_delta/2`/`to_delta!/2`: parse string, apply document pipeline, call converter, wrap errors in `DecodeError`.
- **`test/mdex/slack_converter_test.exs`** — ExUnit tests covering each node type, nested formatting, both public API functions (`to_slack/2`, `to_slack!/2`), custom converter override, and `:skip` return value.

Fixes #333
