### PR TITLE
fix: LiveView 1.2 deprecation warnings( EEx.compile )

### DIFF
--- a/lib/mdex.ex
+++ b/lib/mdex.ex
@@ -524,14 +524,10 @@ defmodule MDEx do
     assigns = options[:assigns] || %{}
 
     rendered =
-      EEx.compile_string(
-        html,
-        engine: Phoenix.LiveView.TagEngine,
+      Phoenix.LiveView.TagEngine.compile(html,
         file: caller.file,
         line: caller.line + 1,
         caller: caller,
-        indentation: 0,
-        source: html,
         tag_handler: Phoenix.LiveView.HTMLEngine
       )
 

--- a/lib/mdex.ex
+++ b/lib/mdex.ex
@@ -523,13 +523,14 @@ defmodule MDEx do
   def __to_heex__({:html, html}, options, caller) do
     assigns = options[:assigns] || %{}
 
+    opts = [file: caller.file, line: caller.line + 1, caller: caller, tag_handler: Phoenix.LiveView.HTMLEngine]
+
     rendered =
-      Phoenix.LiveView.TagEngine.compile(html,
-        file: caller.file,
-        line: caller.line + 1,
-        caller: caller,
-        tag_handler: Phoenix.LiveView.HTMLEngine
-      )
+      if Code.ensure_loaded?(Phoenix.LiveView.TagEngine) and function_exported?(Phoenix.LiveView.TagEngine, :compile, 2) do
+        Phoenix.LiveView.TagEngine.compile(html, opts)
+      else
+        EEx.compile_string(html, opts)
+      end
 
     {rendered, _} = Code.eval_quoted(rendered, [assigns: assigns], Macro.Env.prune_compile_info(caller))
     {:ok, rendered}

--- a/mix.exs
+++ b/mix.exs
@@ -177,7 +177,7 @@ defmodule MDEx.MixProject do
       {:nimble_parsec, "~> 1.0"},
       {:jason, "~> 1.0"},
       {:lumis, "~> 0.1", optional: true},
-      {:phoenix_live_view, "~> 1.2.0", optional: true},
+      {:phoenix_live_view, "~> 1.0", optional: true},
       {:ex_doc, ">= 0.0.0", only: :docs},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -177,7 +177,7 @@ defmodule MDEx.MixProject do
       {:nimble_parsec, "~> 1.0"},
       {:jason, "~> 1.0"},
       {:lumis, "~> 0.1", optional: true},
-      {:phoenix_live_view, "~> 1.0", optional: true},
+      {:phoenix_live_view, "~> 1.2.0", optional: true},
       {:ex_doc, ">= 0.0.0", only: :docs},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false}
     ]


### PR DESCRIPTION
Fix for LiveView 1.2 deprecation warning (#379)