### PR TITLE
chore: release v0.13.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
+## [0.13.6](https://github.com/leandrocp/mdex/compare/v0.13.5...v0.13.6) (2026-08-13)
+
 ### Changes
+
+### Documentation
+
+- Add plugin mdex_multiline_cells by @leandrocp
+
+### Other Changes
+
+- Bump mdex_native and fix tests by @leandrocp in [#389](https://github.com/leandrocp/mdex/pull/389)
 
 ## [0.13.5](https://github.com/leandrocp/mdex/compare/v0.13.4...v0.13.5) (2026-07-29)
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule MDEx.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/leandrocp/mdex"
-  @version "0.13.5"
+  @version "0.13.6"
 
   def project do
     [


### PR DESCRIPTION
Automated Elixir release pull request.

- Bumps the package version to `0.13.6`.
- Updates `CHANGELOG.md` with categorized, contributor-attributed release notes generated by git-cliff.
- Merging this pull request creates tag `v0.13.6` and its GitHub Release.