### PR TITLE
Use the external Lumis NIF for highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,6 @@ def deps do
 end
 ```
 
-```elixir
-config :mdex_native, syntax_highlighter: :lumis
-```
-
 #### GitHub Flavored Markdown (GFM)
 
 _Using the `:html_multi_themes` syntax highlighting formatter is not required but you get light/dark using it._

--- a/guides/code_block_decorators.md
+++ b/guides/code_block_decorators.md
@@ -8,12 +8,6 @@ Code block decorators require Lumis. Add it to your deps:
 {:lumis, "~> 0.1"}
 ```
 
-Configure `:mdex_native` before compiling dependencies:
-
-```elixir
-config :mdex_native, syntax_highlighter: :lumis
-```
-
 To use code block decorators, you must enable both `:render` options:
 
 ```elixir

--- a/guides/compilation.md
+++ b/guides/compilation.md
@@ -34,16 +34,11 @@ mix deps.get
 mix compile
 ```
 
-To enable syntax highlighting with Lumis, add `:lumis` to your deps:
+To enable syntax highlighting with Lumis, add `:lumis` to your deps. MDEx uses
+that dependency automatically when `engine: :lumis` is selected:
 
 ```elixir
 {:lumis, "~> 0.1"}
-```
-
-Then configure `:mdex_native` before compiling dependencies:
-
-```elixir
-config :mdex_native, syntax_highlighter: :lumis
 ```
 
 To use Syntect instead:
@@ -52,14 +47,14 @@ To use Syntect instead:
 config :mdex_native, syntax_highlighter: :syntect
 ```
 
-Disable with `nil` to download a minimal NIF without any syntax highlighter:
+Disable the compiled Syntect engine with `nil` to download the base NIF:
 
 
 ```elixir
 config :mdex_native, syntax_highlighter: nil
 ```
 
-Syntax highlighting is disabled by default in MDEx. Even after compiling `:mdex_native` with Lumis or Syntect, pass `:syntax_highlight` options to enable highlighting for a render.
+Syntax highlighting is disabled by default in MDEx. Pass `:syntax_highlight` options to enable highlighting for a render.
 
 With `syntax_highlight: nil`, MDEx still adds the language class for code blocks but does not syntax highlight them.
 

--- a/guides/compilation.md
+++ b/guides/compilation.md
@@ -34,8 +34,9 @@ mix deps.get
 mix compile
 ```
 
-To enable syntax highlighting with Lumis, add `:lumis` to your deps. MDEx uses
-that dependency automatically when `engine: :lumis` is selected:
+With a bridge-capable `:mdex_native` release, enable syntax highlighting with
+Lumis by adding `:lumis` to your deps. MDEx uses that dependency automatically
+when `engine: :lumis` is selected:
 
 ```elixir
 {:lumis, "~> 0.1"}

--- a/lib/mdex/document.ex
+++ b/lib/mdex/document.ex
@@ -2735,21 +2735,25 @@ defmodule MDEx.Document do
 
   defp legacy_lumis_formatter(formatter), do: formatter
 
-  if Code.ensure_loaded?(Lumis) and function_exported?(Lumis, :__mdex_bridge__, 0) do
-    defp lumis_syntax_highlight_options(options) do
-      options
-      |> Lumis.validate_options!()
-      |> Lumis.rust_options!()
-      |> Map.put(:mdex_bridge, apply(Lumis, :__mdex_bridge__, []))
-    end
-  else
-    if Code.ensure_loaded?(Lumis) do
+  cond do
+    Code.ensure_loaded?(Lumis) and function_exported?(Lumis, :__mdex_bridge__, 0) ->
+      defp lumis_syntax_highlight_options(options) do
+        options
+        |> Lumis.validate_options!()
+        |> Lumis.rust_options!()
+        |> Map.put(:mdex_bridge, Lumis.__mdex_bridge__())
+      end
+
+    # A Lumis without the bridge pairs with an mdex_native that still embeds
+    # its own copy, so highlighting works without one.
+    Code.ensure_loaded?(Lumis) ->
       defp lumis_syntax_highlight_options(options) do
         options
         |> Lumis.validate_options!()
         |> Lumis.rust_options!()
       end
-    else
+
+    true ->
       defp lumis_syntax_highlight_options(_options) do
         raise ArgumentError, """
         Lumis syntax highlighting requires the :lumis dependency.
@@ -2760,7 +2764,6 @@ defmodule MDEx.Document do
 
         """
       end
-    end
   end
 
   defp migrate_header_ids(extension) do

--- a/lib/mdex/document.ex
+++ b/lib/mdex/document.ex
@@ -2735,26 +2735,31 @@ defmodule MDEx.Document do
 
   defp legacy_lumis_formatter(formatter), do: formatter
 
-  if Code.ensure_loaded?(Lumis) do
+  if Code.ensure_loaded?(Lumis) and function_exported?(Lumis, :__mdex_bridge__, 0) do
     defp lumis_syntax_highlight_options(options) do
       options
       |> Lumis.validate_options!()
       |> Lumis.rust_options!()
+      |> Map.put(:mdex_bridge, apply(Lumis, :__mdex_bridge__, []))
     end
   else
-    defp lumis_syntax_highlight_options(_options) do
-      raise ArgumentError, """
-      Lumis syntax highlighting requires the :lumis dependency.
+    if Code.ensure_loaded?(Lumis) do
+      defp lumis_syntax_highlight_options(options) do
+        options
+        |> Lumis.validate_options!()
+        |> Lumis.rust_options!()
+      end
+    else
+      defp lumis_syntax_highlight_options(_options) do
+        raise ArgumentError, """
+        Lumis syntax highlighting requires the :lumis dependency.
 
-      Add it to your deps:
+        Add it to your deps:
 
-          {:lumis, "~> 0.1"}
+            {:lumis, "~> 0.1"}
 
-      And configure :mdex_native before compiling dependencies:
-
-          config :mdex_native, syntax_highlighter: :lumis
-
-      """
+        """
+      end
     end
   end
 

--- a/test/mdex/document_test.exs
+++ b/test/mdex/document_test.exs
@@ -1541,6 +1541,7 @@ defmodule MDEx.DocumentTest do
 
       assert %{engine: :lumis, opts: %{formatter: {:html_inline, formatter_opts}}} = options.syntax_highlight
       assert formatter_opts.theme == {:string, "github_light"}
+      assert_lumis_bridge(options.syntax_highlight.opts)
     end
 
     test "preserves the MDEx theme for legacy html_inline formatter defaults" do
@@ -1575,6 +1576,7 @@ defmodule MDEx.DocumentTest do
       assert %{engine: :lumis, opts: %{formatter: {:html_inline, formatter_opts}}} = options.syntax_highlight
       assert formatter_opts.theme == {:string, "github_light"}
       assert formatter_opts.pre_class == "code-block-example"
+      assert_lumis_bridge(options.syntax_highlight.opts)
     end
 
     test "converts syntect engine and opts to native syntax highlight options" do
@@ -1590,6 +1592,14 @@ defmodule MDEx.DocumentTest do
                    fn ->
                      Document.rust_options!(syntax_highlight: [engine: :syntect, formatter: :html_inline])
                    end
+    end
+  end
+
+  defp assert_lumis_bridge(options) do
+    if function_exported?(Lumis, :__mdex_bridge__, 0) do
+      assert is_reference(options.mdex_bridge)
+    else
+      refute Map.has_key?(options, :mdex_bridge)
     end
   end
 

--- a/test/mdex/document_test.exs
+++ b/test/mdex/document_test.exs
@@ -1596,7 +1596,7 @@ defmodule MDEx.DocumentTest do
   end
 
   defp assert_lumis_bridge(options) do
-    if function_exported?(Lumis, :__mdex_bridge__, 0) do
+    if Code.ensure_loaded?(Lumis) and function_exported?(Lumis, :__mdex_bridge__, 0) do
       assert is_reference(options.mdex_bridge)
     else
       refute Map.has_key?(options, :mdex_bridge)


### PR DESCRIPTION
## Summary

- attach Lumis's versioned NIF resource to mdex_native options when the optional `:lumis` dependency is compiled into the application
- remove the obsolete user-facing `config :mdex_native, syntax_highlighter: :lumis` requirement
- retain compile-time compatibility with the currently released Lumis/mdex_native pair while the two dependency PRs are released

Depends on leandrocp/lumis#1332 and leandrocp/mdex_native#57.

## Validation

- `mix test` against the currently locked released dependencies (801 passed)
- mdex_native CI cloned this branch and ran the MDEx suite against the exact Lumis and mdex_native PR heads (2 E2E passed, 1 excluded overall)
- `mix format --check-formatted lib/mdex/document.ex test/mdex/document_test.exs`
- all three PR SHAs built from source in Linux ARM64 with Elixir 1.15.8, OTP 24.3.4.17, and NIF 2.16; both MDEx and direct MDExNative Lumis rendering passed
