### PR TITLE
feat: add native Markdown streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ### Changes
 
+* Add `MDEx.stream/2`. It turns an Enumerable of Markdown chunks into a lazy
+  Elixir Stream of keyed `MDEx.Document` values.
+* Deprecate `MDEx.new(streaming: true)`. Use `MDEx.stream/2` for chunked input.
+  `MDEx.Document.put_markdown/3` remains supported for building one document.
+* Require `mdex_native >= 0.2.9` for link-reference metadata from the parser.
+
 ## [0.13.5](https://github.com/leandrocp/mdex/compare/v0.13.4...v0.13.5) (2026-07-29)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   Elixir Stream of keyed `MDEx.Document` values.
 * Deprecate `MDEx.new(streaming: true)`. Use `MDEx.stream/2` for chunked input.
   `MDEx.Document.put_markdown/3` remains supported for building one document.
-* Require `mdex_native >= 0.2.9` for link-reference metadata from the parser.
+* Require `mdex_native >= 0.2.10` for link-reference metadata from the parser.
 
 ## [0.13.5](https://github.com/leandrocp/mdex/compare/v0.13.4...v0.13.5) (2026-07-29)
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,6 @@
 # MDEx streaming progress
 
-Last updated: 2026-08-29
+Last updated: 2026-08-30
 
 ## Goal
 
@@ -67,11 +67,15 @@ The Stream implementation:
 - starts parser state when enumeration starts
 - reads upstream only when downstream asks for a chunk
 - emits keyed `MDEx.Document` values
-- builds each document through `put_markdown/3`
+- runs every emitted document through the normal `MDEx.Document` plugin pipeline
 - holds an incomplete UTF-8 suffix between source chunks
 - keeps only the Markdown suffix that may still change
 - uses fragment parsing for that open suffix
-- uses normal parsing for stable chunks and EOF
+- emits stable AST nodes from the metadata parse without parsing them again
+- keeps the normal open AST for EOF instead of parsing it again
+- attaches plugins once per Stream enumeration
+- applies plugin parser options before metadata and fragment parsing
+- runs a fresh copy of the plugin pipeline for every emitted document
 - cleans up when the source ends, raises, or is stopped early
 - raises bad chunks, invalid UTF-8, and upstream errors during enumeration
 
@@ -102,7 +106,7 @@ out of link-reference metadata.
 
 MDEx uses the returned source line to keep only the required suffix open.
 
-MDEx now requires mdex_native 0.2.9. That version must be released before this
+MDEx now requires mdex_native 0.2.10. That version must be released before this
 MDEx branch can pass dependency setup without a local path.
 
 ## Phoenix LiveView findings
@@ -230,8 +234,8 @@ Completed:
 - mdex_native: 4 Rust tests and 56 Elixir tests (22 doctests and 34 tests)
 - mdex_native: Clippy with warnings denied, Rust format, Elixir format, and
   `git diff --check`
-- MDEx: 14 focused Stream tests
-- MDEx: 812 full tests (62 doctests and 750 tests)
+- MDEx: 18 focused Stream tests
+- MDEx: 818 full tests (62 doctests and 756 tests)
 - MDEx: compile with warnings denied, docs with warnings denied, format, and
   `git diff --check`
 - Phoenix example: 2 integration tests, including the raw GitHub README
@@ -252,10 +256,9 @@ The Ash AI `reuse` check was not run because `pipx` was not installed.
 
 ## Work before release
 
-- Define support for plugins that read or change the whole document.
 - Review whether the API is ready for MDEx 0.14.
-- Release mdex_native 0.2.9 and its precompiled files.
-- Run MDEx CI against mdex_native 0.2.9 from Hex.
+- Release mdex_native 0.2.10 and its precompiled files.
+- Run MDEx CI against mdex_native 0.2.10 from Hex.
 - Replace each client's local MDEx path with the released version.
 - Run each client's CI on its declared Elixir and OTP versions.
 - Open separate client pull requests only after those checks pass.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,0 +1,270 @@
+# MDEx streaming progress
+
+Last updated: 2026-08-29
+
+## Goal
+
+Add a lazy Elixir Stream API for Markdown chunks. MDEx should parse partial
+Markdown and decide which output can no longer change.
+
+Validate the API before release with:
+
+- a Req and Phoenix LiveView example in MDEx
+- Loopyard
+- phoenix_streamdown
+- Ash AI
+
+See these files for public details:
+
+- [`guides/streaming.md`](guides/streaming.md): user guide
+- [`STREAMING_API.md`](STREAMING_API.md): API contract and design notes
+- [`examples/streaming.exs`](examples/streaming.exs): runnable Phoenix example
+
+## Branches
+
+The MDEx branch is the pull request target. mdex_native and the three client
+branches remain local and uncommitted.
+
+| Project | Branch | Base |
+| --- | --- | --- |
+| MDEx | `lp-loopyard-streaming` | `931cb825` |
+| mdex_native | `lp-mdex-stream-metadata` | `b3c77b2` |
+| Loopyard | `lp-mdex-native-stream` | `8bc934a5` |
+| phoenix_streamdown | `lp-mdex-native-stream` | `4757f76e` |
+| Ash AI | `lp-mdex-native-stream` | `043461cc` |
+
+Each client uses the local MDEx branch. MDEx uses the local mdex_native branch.
+This tests the two unreleased APIs together.
+
+## API
+
+```elixir
+File.stream!(path)
+|> MDEx.stream(options)
+|> Enum.each(&consume/1)
+```
+
+`MDEx.stream/2` accepts an Enumerable of binary chunks and returns a lazy
+`%Stream{}`. It emits:
+
+```elixir
+{id, %MDEx.Document{}}
+```
+
+An id may repeat while that chunk is still open. A higher id makes all lower
+ids stable. EOF emits the last chunk with a normal parse, then ends the Stream.
+
+The API has no public parser state, frame, block, or `new/push/finish` type.
+
+`MDEx.new/1` and `MDEx.Document.put_markdown/3` remain supported. Only
+`MDEx.new(streaming: true)` is deprecated. It warns and keeps its current
+behavior for now.
+
+## MDEx changes
+
+The Stream implementation:
+
+- starts parser state when enumeration starts
+- reads upstream only when downstream asks for a chunk
+- emits keyed `MDEx.Document` values
+- builds each document through `put_markdown/3`
+- holds an incomplete UTF-8 suffix between source chunks
+- keeps only the Markdown suffix that may still change
+- uses fragment parsing for that open suffix
+- uses normal parsing for stable chunks and EOF
+- cleans up when the source ends, raises, or is stopped early
+- raises bad chunks, invalid UTF-8, and upstream errors during enumeration
+
+Covered Markdown cases include:
+
+- loose lists
+- partial tables
+- tilde and longer backtick fences
+- partial emphasis and links
+- link references
+- one-grapheme source chunks
+
+Block boundaries come from CommonMark source positions. A gap between top-level
+node line ranges marks a blank-line boundary. No regular expression parses
+blank lines, fences, or link references.
+
+A link that may use a later definition keeps its block and all following blocks
+open. Partial tables have a separate guard because their temporary parser shape
+can change when more source arrives.
+
+## mdex_native changes
+
+mdex_native adds `parse_document_with_metadata/2`.
+
+It uses Comrak parser data to report the first top-level block that may use a
+later link definition. It uses Comrak task-list nodes to keep `[x]` task marks
+out of link-reference metadata.
+
+MDEx uses the returned source line to keep only the required suffix open.
+
+MDEx now requires mdex_native 0.2.9. That version must be released before this
+MDEx branch can pass dependency setup without a local path.
+
+## Phoenix LiveView findings
+
+Use this process split:
+
+```text
+source Enumerable
+  -> MDEx.stream/2 in a task or process
+  -> finite {id, document} messages or lists
+  -> Phoenix.LiveView.stream_insert/4 or stream/4
+  -> keyed DOM children
+```
+
+Verified with Phoenix LiveView 1.2.11:
+
+- `stream/4` reads the given Enumerable in the LiveView process.
+- A long-running MDEx Stream must not be passed directly to `stream/4`.
+- A `start_async/3` task may read MDEx and send finite updates while it runs.
+- `stream_async/4` waits for its task result before it calls `stream/4`.
+- `stream_insert/4` replaces an entry when its DOM id repeats.
+- The parent needs `phx-update="stream"`.
+- Each child must use the exact DOM id from LiveView.
+- LiveView removes streamed values from socket state after rendering.
+- A new response must reset the stream or add its own response id to each DOM
+  id.
+
+## Phoenix example
+
+The example runs this path:
+
+```text
+Req async response
+  -> 64-byte display chunks
+  -> MDEx.stream/2
+  -> LiveView process messages
+  -> stream_insert/4
+  -> LiveView stream DOM
+```
+
+It includes:
+
+- a URL field that defaults to the raw MDEx README
+- a response body-size limit
+- task cancellation and stale-message checks
+- a delay slider from 0 to 1000 ms
+- an auto-scroll checkbox
+- Lumis highlighting for partial code fences
+- a Lumis-highlighted "How it works" panel
+- source byte and chunk counts
+- MDEx update and replacement counts
+- stable and open DOM chunk counts
+- current and peak memory for the producer and LiveView processes
+
+## Loopyard validation
+
+The old code parsed each viewer's full Markdown snapshots. It used blank-line
+and fence rules, plus a JavaScript hook for the open HTML tail.
+
+The old code failed 6 of 18 focused cases:
+
+- partial bold and links were not closed for display
+- tilde and four-backtick fences split at the wrong place
+- a loose list became several lists
+- a later link definition changed an earlier stable block
+
+The local branch reads the backend Enumerable once:
+
+```text
+backend stream
+  -> raw event handling
+  -> text chunks
+  -> MDEx.stream/2 once per agent turn
+  -> keyed Markdown updates
+  -> existing 100 ms buffer
+  -> LiveView stream inserts
+```
+
+Raw events still handle storage, tools, status, final text, timeouts, and stale
+stream checks. Parsed documents are shared through PubSub.
+
+The branch removes the custom Markdown parser, JavaScript hook, and
+phoenix_streamdown dependency. The 100 ms buffer keeps the newest value for
+each id, not only the last value it receives.
+
+## phoenix_streamdown validation
+
+The released code repairs and splits the full Markdown string before it calls
+MDEx. The local branch removes those parsing modules:
+
+```text
+source chunks -> MDEx.stream/2 -> LiveView stream -> component
+```
+
+MDEx owns Markdown parsing, partial syntax, ids, and EOF. phoenix_streamdown
+keeps static rendering, components, styles, themes, and optional animation.
+
+Its ReqLLM example now sends model text chunks through MDEx and inserts the
+keyed documents into a LiveView stream.
+
+## Ash AI validation
+
+Ash AI already uses MDEx for final HTML. Its generated UI used full text
+snapshots, and its tool loop built a list for each model step before yielding
+events.
+
+The local branch makes the tool loop lazy and stops the provider when
+downstream stops. The generated job:
+
+```text
+provider stream
+  -> persist raw events
+  -> text chunks
+  -> MDEx.stream/2
+  -> conversation PubSub topic
+  -> LiveView or LiveComponent stream inserts
+```
+
+Final stored messages still use the normal static MDEx renderer.
+
+## Test results
+
+Completed:
+
+- mdex_native: 4 Rust tests and 56 Elixir tests (22 doctests and 34 tests)
+- mdex_native: Clippy with warnings denied, Rust format, Elixir format, and
+  `git diff --check`
+- MDEx: 14 focused Stream tests
+- MDEx: 812 full tests (62 doctests and 750 tests)
+- MDEx: compile with warnings denied, docs with warnings denied, format, and
+  `git diff --check`
+- Phoenix example: 2 integration tests, including the raw GitHub README
+- Phoenix example: delay, auto-scroll, partial Lumis highlighting, the "How it
+  works" panel, and non-zero telemetry values
+- Loopyard: 1,901 tests passed; 122 environment tests excluded
+- Loopyard: focused stream tests, asset build, compile with warnings denied,
+  format, and `git diff --check`
+- phoenix_streamdown library: `mix ci`, 24 tests, Credo, and Dialyzer
+- phoenix_streamdown example: 8 tests and pre-commit checks on Elixir 1.19.3
+  with OTP 28.5
+- Ash AI: 351 tests passed; 28 excluded
+- Ash AI: compile, format, dependency audit, Credo, Sobelow, ExDoc, ExUnit, and
+  Dialyzer
+- all five worktrees: `git diff --check`
+
+The Ash AI `reuse` check was not run because `pipx` was not installed.
+
+## Work before release
+
+- Define support for plugins that read or change the whole document.
+- Review whether the API is ready for MDEx 0.14.
+- Release mdex_native 0.2.9 and its precompiled files.
+- Run MDEx CI against mdex_native 0.2.9 from Hex.
+- Replace each client's local MDEx path with the released version.
+- Run each client's CI on its declared Elixir and OTP versions.
+- Open separate client pull requests only after those checks pass.
+
+## Local test notes
+
+Ash AI database tests used a temporary PostgreSQL 17 server with pgvector. The
+server was stopped after the tests.
+
+The exact Elixir and OTP versions pinned by the phoenix_streamdown example were
+not installed. Its checks passed on the nearest installed stable pair: Elixir
+1.19.3 and OTP 28.5.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 - Discord Flavored Markdown (Partial)
 - Wiki-style links
 - Phoenix HEEx components and expressions
-- [Streaming](https://hexdocs.pm/mdex/streaming.html) incomplete fragments
+- Native Elixir [Stream](https://hexdocs.pm/mdex/streaming.html) for Markdown chunks
 - [Emoji](https://www.webfx.com/tools/emoji-cheat-sheet) shortcodes
 - Built-in Syntax Highlighting with [Lumis](https://mdex.hexdocs.pm/lumis.html) or [Syntect](https://mdex.hexdocs.pm/syntect.html)
 - [Code Block Decorators](https://hexdocs.pm/mdex/code_block_decorators-2.html)
@@ -160,12 +160,23 @@ iex> ~MD[# Hello :smile:]
 ```
 
 #### Streaming
+
 ```elixir
-iex> MDEx.new(streaming: true)
-...> |> MDEx.Document.put_markdown("**Install")
-...> |> MDEx.to_html!()
-"<p><strong>Install</strong></p>"
+iex> ["# Hel", "lo\n\nNow **wri", "ting**"]
+...> |> MDEx.stream()
+...> |> Enum.map(fn {id, document} -> {id, MDEx.to_html!(document)} end)
+[
+  {0, "<h1>Hel</h1>"},
+  {0, "<h1>Hello</h1>"},
+  {1, "<p>Now <strong>wri</strong></p>"},
+  {1, "<p>Now <strong>writing</strong></p>"},
+  {1, "<p>Now <strong>writing</strong></p>"}
+]
 ```
+
+Insert a chunk when its id is new. Replace it when the id repeats. See the
+[Streaming guide](https://hexdocs.pm/mdex/streaming.html) for files, Req, and
+Phoenix LiveView.
 
 ## Examples and Guides
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@
 - [mdex_mermex](https://hex.pm/packages/mdex_mermex) - Render [Mermaid](https://mermaid.js.org) diagrams server-side using Mermex (Rust NIF)
 - [mdex_multiline_cells](https://hex.pm/packages/mdex_multiline_cells) - Multi-line cells in Markdown tables with inline/block Markdown rendering
 
+Plugins can be passed to `MDEx.stream/2`, but each plugin step receives one
+keyed document rather than the full Markdown response. See the
+[streaming plugin rules](https://hexdocs.pm/mdex/streaming.html#plugins) before
+using plugins that inject assets, generate document-wide IDs, or preprocess
+Markdown source.
+
 ## Installation
 
 Add `:mdex` dependency:

--- a/STREAMING_API.md
+++ b/STREAMING_API.md
@@ -1,0 +1,372 @@
+# MDEx Stream API
+
+Status: implemented on the development branch; not released.
+
+## API decision
+
+MDEx adds one public API for Markdown that arrives in chunks:
+
+```elixir
+MDEx.stream(chunks, options \\ [])
+```
+
+Input:
+
+- any `Enumerable` that emits binaries
+- normal MDEx document options
+
+Output:
+
+- a lazy Elixir `%Stream{}`
+- `{id, %MDEx.Document{}}` for each update
+
+```elixir
+@type stream_id :: non_neg_integer()
+@type stream_chunk :: {stream_id(), MDEx.Document.t()}
+
+@spec stream(Enumerable.t(), MDEx.Document.options()) :: Enumerable.t()
+```
+
+The API does not expose a stream state struct or a `new/push/finish` protocol.
+Its state stays inside `Stream.transform/5`.
+
+`MDEx.new(streaming: true)` is deprecated. `MDEx.new/1` and
+`MDEx.Document.put_markdown/3` remain supported for building one document.
+
+## Why the output is keyed
+
+Partial Markdown cannot use append-only output. For example, `Now **wri` must
+render as valid HTML, then be replaced when `ting**` arrives.
+
+The id tells a consumer when to insert or replace a chunk. The value is a
+document, so the consumer may render HTML, CommonMark, XML, JSON, Quill Delta,
+or read the AST.
+
+Each update contains a new immutable document. MDEx does not change an earlier
+document in place.
+
+## Basic use
+
+```elixir
+chunks = ["# Hel", "lo\n\nNow **wri", "ting**"]
+
+chunks
+|> MDEx.stream()
+|> Stream.map(fn {id, document} ->
+  {id, MDEx.to_html!(document)}
+end)
+|> Enum.each(&update_output/1)
+```
+
+`File.stream!/1` works without an adapter:
+
+```elixir
+"README.md"
+|> File.stream!([], 2048)
+|> MDEx.stream(extension: [table: true])
+|> Enum.each(&consume/1)
+```
+
+Req can also provide the source:
+
+```elixir
+response = Req.get!(url, into: :self, raw: true)
+
+response.body
+|> MDEx.stream(options)
+|> Enum.each(&consume/1)
+```
+
+MDEx holds an incomplete UTF-8 suffix when a file or network read splits a
+code point. The caller does not need to fix those boundaries.
+
+## Id rules
+
+There is at most one open chunk.
+
+For this input:
+
+```elixir
+["# Done\n\nNow **wri", "ting**"]
+```
+
+the output has this form:
+
+```elixir
+{0, heading_document}           # insert
+{1, partial_paragraph_document} # insert
+{1, updated_paragraph_document} # replace
+{1, final_paragraph_document}   # replace at EOF
+```
+
+The exact number of updates is private. The id rules are public:
+
+1. Ids start at `0` for each Stream run.
+2. Ids increase in order.
+3. A repeated id replaces the earlier value for that id.
+4. After a higher id is emitted, every lower id is stable.
+5. Only the highest id may be emitted again.
+6. EOF emits the last chunk with a normal final parse, then ends the Stream.
+7. Empty input emits no chunks.
+
+One keyed document may hold several top-level Markdown blocks. This is needed
+when a later link definition or another document-wide rule may change a group
+of blocks.
+
+The end of the Stream is the completion signal. There is no `done?` field or
+EOF value. If downstream stops early, MDEx does not finalize unread input.
+
+## Relationship to `put_markdown/3`
+
+`MDEx.Document.put_markdown/3` is the lower-level API for adding source to one
+document. It remains useful for AST pipelines and full document renders.
+
+Use the two APIs as follows:
+
+```elixir
+# An Enumerable of chunks
+File.stream!(path)
+|> MDEx.stream(options)
+|> Enum.each(&consume/1)
+
+# One document built in steps
+document =
+  MDEx.new(options)
+  |> MDEx.Document.put_markdown(first_chunk)
+  |> MDEx.Document.put_markdown(second_chunk)
+
+MDEx.to_html!(document)
+```
+
+`MDEx.stream/2` uses `put_markdown/3` to build emitted documents. Fragment
+parsing is private and is enabled only for the open chunk.
+
+Tests must keep these rules true:
+
+- source chunk boundaries do not add or remove bytes
+- the final Stream render matches a full document render
+- the open chunk uses the same fragment parser as MDEx
+- parse and render options reach each document
+- EOF removes temporary fragment closing syntax
+
+## Lazy behavior
+
+The Stream uses `Stream.transform/5`:
+
+- parser state is created when enumeration starts
+- upstream chunks are read only when downstream asks for them
+- normal EOF emits the final document
+- an early halt does not act like EOF
+- cleanup runs after completion, halt, or error
+- a second run creates new state when the source can be read again
+- bad chunks, invalid UTF-8, and upstream errors raise during enumeration
+
+`Stream.transform/5` is available in Elixir 1.14. MDEx requires Elixir 1.15 or
+later.
+
+## Phoenix LiveView
+
+Phoenix LiveView streams store keyed DOM updates. They do not keep MDEx parser
+state and do not read a long-running source in the background.
+
+This split is required:
+
+```text
+source Enumerable
+  -> MDEx.stream/2 in a task or process
+  -> finite {id, document} messages or lists
+  -> Phoenix.LiveView.stream_insert/4 or stream/4
+  -> phx-update="stream" DOM children
+```
+
+The
+[`Phoenix.LiveView.stream/4` docs](https://phoenix-live-view.hexdocs.pm/Phoenix.LiveView.html#stream/4)
+define the DOM contract:
+
+- the parent has a unique id and `phx-update="stream"`
+- each child uses the exact DOM id from `@streams.name`
+- `stream_insert/4` updates an entry when its DOM id already exists
+- LiveView drops streamed entries from socket state after rendering
+
+The LiveView 1.2.11 source also shows that `stream/4` reads the given Enumerable
+in the LiveView process. It keeps the last insert for a repeated DOM id within
+one render.
+
+### Configure ids
+
+```elixir
+def mount(_params, _session, socket) do
+  {:ok,
+   socket
+   |> stream_configure(:markdown, dom_id: fn {id, _document} ->
+     "markdown-#{id}"
+   end)
+   |> stream(:markdown, [])}
+end
+```
+
+```heex
+<div id="markdown" class="markdown-body" phx-update="stream">
+  <div
+    :for={{dom_id, {_id, document}} <- @streams.markdown}
+    id={dom_id}
+    class="contents"
+  >
+    {Phoenix.HTML.raw(MDEx.to_html!(document))}
+  </div>
+</div>
+```
+
+Do not change `dom_id` in the template. Check that `class="contents"` matches
+the application's CSS and access needs. Apply the required MDEx safety options
+before using `Phoenix.HTML.raw/1`.
+
+### Read MDEx outside the callback
+
+This blocks a LiveView callback until the source ends:
+
+```elixir
+stream(socket, :markdown, MDEx.stream(long_running_chunks))
+```
+
+Run the source in a task and send finite updates:
+
+```elixir
+def start_markdown(socket, chunks) do
+  live_view = self()
+
+  start_async(socket, :markdown_producer, fn ->
+    chunks
+    |> MDEx.stream(@mdex_options)
+    |> Enum.each(&send(live_view, {:markdown_chunk, &1}))
+  end)
+end
+
+def handle_info({:markdown_chunk, chunk}, socket) do
+  {:noreply, stream_insert(socket, :markdown, chunk)}
+end
+
+def handle_async(:markdown_producer, {:ok, :ok}, socket) do
+  {:noreply, socket}
+end
+```
+
+`start_async/3` works here because the task reads MDEx and sends updates while
+it runs. `stream_async/4` is different: it waits for the task result, then gives
+that result to `stream/4`.
+
+A client may send finite batches instead:
+
+```elixir
+def handle_info({:markdown_chunks, chunks}, socket) do
+  {:noreply, stream(socket, :markdown, chunks)}
+end
+```
+
+LiveView may keep only the newest value when one batch has several updates for
+the same id. This is safe because the newest value replaces the same open
+chunk.
+
+The source and MDEx state stay in the producer. The LiveView stream only sends
+DOM changes.
+
+Reset the LiveView stream for a new response, or add a response id to each DOM
+id. MDEx ids are local to one Stream run.
+
+## Client validation
+
+Three local client branches test the same API.
+
+### Loopyard
+
+Loopyard already has an Enumerable for each backend turn. The branch reads it
+once:
+
+```elixir
+backend.stream(session, prompt)
+|> Stream.each(&send(chat_agent, {:stream_event, &1}))
+|> Stream.flat_map(fn
+  %Event.TextDelta{text: text} -> [text]
+  _event -> []
+end)
+|> MDEx.stream(mdex_options)
+|> Enum.each(&send(chat_agent, {:markdown_update, &1}))
+```
+
+Raw events still handle storage, tools, status, and final text. Parsed
+documents are shared with all viewers. The branch removes the custom Markdown
+split code and JavaScript update hook.
+
+The client's 100 ms buffer keeps the newest value for every id. It must keep
+more than the last emitted value because one source chunk can close one id and
+open the next id.
+
+### phoenix_streamdown
+
+The released package repairs and splits a full Markdown string before it calls
+MDEx. Its local branch removes that parser-like code:
+
+```text
+source chunks -> MDEx.stream/2 -> LiveView stream -> component
+```
+
+MDEx parses Markdown and owns ids. phoenix_streamdown keeps its components,
+styles, themes, and optional text animation.
+
+### Ash AI
+
+Ash AI already uses MDEx for final HTML. Its local branch makes the tool loop
+lazy and sends text chunks through MDEx:
+
+```elixir
+prompt_messages
+|> AshAi.ToolLoop.stream(options)
+|> Stream.each(&persist_event/1)
+|> Stream.flat_map(fn
+  {:content, chunk} -> [chunk]
+  _event -> []
+end)
+|> MDEx.stream(markdown_options())
+|> Enum.each(&broadcast_markdown/1)
+```
+
+The generated job sends keyed documents through PubSub. LiveView and
+LiveComponent code insert them into a LiveView stream. Final stored messages
+still use normal static MDEx rendering.
+
+## Parser requirements
+
+The parser must keep these cases correct:
+
+- a loose list stays one list
+- a partial table does not become stable too soon
+- tilde fences and longer backtick fences use parser rules
+- partial emphasis, links, tables, math, HTML, and fences render as valid
+  open chunks
+- a later link or footnote definition can keep several blocks under one id
+- a blank line at the current end of input does not always make a block stable
+
+The implementation uses CommonMark source positions for block boundaries. It
+does not use regular expressions to parse blank lines, fences, or references.
+
+## Release checklist
+
+- [x] Add `MDEx.stream/2` with `Stream.transform/5`.
+- [x] Keep all stream state private.
+- [x] Use `MDEx.Document.put_markdown/3` for input.
+- [x] Parse the open chunk with the MDEx fragment parser.
+- [x] Handle UTF-8 code points split across chunks.
+- [x] Test errors, cleanup, early halt, and EOF.
+- [x] Test final output against full document parsing.
+- [x] Add a Phoenix Playground example with Req and LiveView.
+- [x] Test local branches for Loopyard, phoenix_streamdown, and Ash AI.
+- [ ] Define support for plugins that read or change the whole document.
+- [ ] Release mdex_native 0.2.9 with the new parser metadata function.
+- [ ] Run each client against the released MDEx package.
+
+## Open question
+
+The remaining API question is plugin support. A plugin that reads or changes
+the whole document may produce a different result when each keyed document is
+rendered on its own. Such plugins may need to keep the full open suffix under
+one id, or may not support streaming.

--- a/STREAMING_API.md
+++ b/STREAMING_API.md
@@ -45,6 +45,26 @@ or read the AST.
 Each update contains a new immutable document. MDEx does not change an earlier
 document in place.
 
+The document is the parsed AST. Consumers can change it before rendering:
+
+```elixir
+chunks
+|> MDEx.stream()
+|> Stream.map(fn {id, document} ->
+  document =
+    MDEx.Document.update_nodes(document, MDEx.Link, fn link ->
+      %{link | url: rewrite_url(link.url)}
+    end)
+
+  {id, MDEx.to_html!(document)}
+end)
+```
+
+The transform runs for each emitted document. It does not receive the full
+response. Chunk-local transforms work directly. Transforms that need all
+chunks must wait for the full source or keep their own state, including state
+for a repeated open id.
+
 ## Basic use
 
 ```elixir
@@ -138,8 +158,10 @@ document =
 MDEx.to_html!(document)
 ```
 
-`MDEx.stream/2` uses `put_markdown/3` to build emitted documents. Fragment
-parsing is private and is enabled only for the open chunk.
+`MDEx.stream/2` uses the same parser options and document plugin pipeline as
+`put_markdown/3`. For the open chunk, it parses fragment-completed source. For
+stable chunks and EOF, it uses the normal AST returned by the metadata parse
+instead of parsing the same source again.
 
 Tests must keep these rules true:
 
@@ -163,6 +185,37 @@ The Stream uses `Stream.transform/5`:
 
 `Stream.transform/5` is available in Elixir 1.14. MDEx requires Elixir 1.15 or
 later.
+
+## Parser reuse
+
+The metadata parse returns both block facts and the normal AST. MDEx emits the
+parsed nodes for stable chunks and keeps the normal AST for EOF. It does not
+parse those sources again.
+
+The open chunk still needs one extra parse after fragment completion. That
+parse produces valid output for partial Markdown. At EOF, MDEx replaces it with
+the normal AST saved by the metadata parse.
+
+## Plugins
+
+Plugins use the normal `:plugins` option. MDEx attaches them once in the lazy
+Stream initializer and keeps the resulting document as an immutable template.
+This makes parser options configured by a plugin available to the metadata and
+fragment parses.
+
+For each emitted update, MDEx starts from the template, installs the parsed
+nodes, and runs the configured pipeline steps. The completed document is not
+used as the template for the next update. Plugin state from one update does not
+leak into a repeated id.
+
+This supports parser-configuration plugins and chunk-local AST transforms. It
+does not provide full-response plugin semantics. Root assets may be repeated,
+sequence IDs restart per keyed chunk, and a step cannot inspect stable chunks
+that were already emitted.
+
+Plugin attachment happens before the source Enumerable is read. A plugin that
+rewrites `document.buffer` in `attach/2` is not compatible with this API and
+must use the one-document pipeline after the full source is available.
 
 ## Phoenix LiveView
 
@@ -361,7 +414,7 @@ does not use regular expressions to parse blank lines, fences, or references.
 - [x] Add a Phoenix Playground example with Req and LiveView.
 - [x] Test local branches for Loopyard, phoenix_streamdown, and Ash AI.
 - [ ] Define support for plugins that read or change the whole document.
-- [ ] Release mdex_native 0.2.9 with the new parser metadata function.
+- [ ] Release mdex_native 0.2.10 with the new parser metadata function.
 - [ ] Run each client against the released MDEx package.
 
 ## Open question

--- a/examples/streaming.exs
+++ b/examples/streaming.exs
@@ -1,144 +1,21 @@
+mdex_path = System.get_env("MDEX_PATH", Path.expand("..", __DIR__))
+
 Mix.install(
   [
-    {:mdex, "~> 0.10"},
-    {:lumis, "~> 0.1"},
-    {:phoenix_playground, "~> 0.1"}
+    {:mdex, path: mdex_path},
+    {:lumis, "~> 0.6"},
+    {:phoenix_playground, "~> 0.1.9"},
+    {:req, "~> 0.7.4"}
   ],
   config: [mdex_native: [syntax_highlighter: :lumis]]
 )
 
-defmodule DemoLayout do
-  use Phoenix.Component
-
-  def render("root.html", assigns) do
-    ~H"""
-    <!DOCTYPE html>
-    <html lang="en" class="h-full">
-      <head>
-        <meta charset="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <title>MDEx Streaming Demo</title>
-        <link rel="icon" type="image/png" href="../assets/images/mdex_favicon.png">
-      </head>
-      <body>
-        <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
-        <script src="/assets/phoenix/phoenix.js"></script>
-        <script src="/assets/phoenix_live_view/phoenix_live_view.js"></script>
-
-        <script>
-          let liveSocket =
-            new window.LiveView.LiveSocket(
-              "/live",
-              window.Phoenix.Socket
-            )
-          liveSocket.connect()
-
-          window.addEventListener("phx:live_reload:attached", ({detail: reloader}) => {
-            reloader.enableServerLogs()
-            window.liveReloader = reloader
-          })
-
-          window.addEventListener("phx:update", () => {
-            const chunksContainer = document.getElementById("chunks-container")
-            const renderedContainer = document.getElementById("rendered-container")
-            if (chunksContainer) {
-              chunksContainer.scrollTop = chunksContainer.scrollHeight
-            }
-            if (renderedContainer) {
-              renderedContainer.scrollTop = renderedContainer.scrollHeight
-            }
-          })
-        </script>
-
-        <%= @inner_content %>
-      </body>
-    </html>
-    """
-  end
-end
-
-defmodule RenderPanel do
-  use Phoenix.LiveComponent
-
-  def render(assigns) do
-    ~H"""
-    <div class="bg-white/70 dark:bg-slate-900/70 backdrop-blur-xl rounded-2xl shadow-xl border border-slate-200/50 dark:border-slate-800/50 overflow-hidden">
-      <div class="px-6 py-4 bg-gradient-to-r from-slate-50 to-white dark:from-slate-900 dark:to-slate-800/50 border-b border-slate-200 dark:border-slate-700/50">
-        <h3 class="text-base font-bold text-slate-900 dark:text-white">Rendered Output</h3>
-      </div>
-      <div class="p-6">
-        <div id="rendered-container" class="max-h-[50vh] overflow-y-auto">
-          <%= if @html == "" do %>
-            <div class="text-slate-500 dark:text-slate-400 text-center py-12">
-              Rendered output will appear here
-            </div>
-          <% else %>
-            <div class={"prose prose-slate dark:prose-invert max-w-none
-                         [&_h1]:text-2xl [&_h1]:font-bold [&_h1]:mb-4 [&_h1]:mt-6 [&_h1]:text-slate-900 dark:[&_h1]:text-white
-                         [&_h2]:text-xl [&_h2]:font-bold [&_h2]:mb-3 [&_h2]:mt-5 [&_h2]:text-slate-900 dark:[&_h2]:text-white
-                         [&_h3]:text-lg [&_h3]:font-semibold [&_h3]:mb-2 [&_h3]:mt-4 [&_h3]:text-slate-900 dark:[&_h3]:text-white
-                         [&_p]:mb-4 [&_p]:leading-7 [&_p]:text-slate-700 dark:[&_p]:text-slate-300
-                         [&_ul]:my-4 [&_ul]:pl-6 [&_ul]:list-disc [&_ul]:space-y-2
-                         [&_ol]:my-4 [&_ol]:pl-6 [&_ol]:list-decimal [&_ol]:space-y-2
-                         [&_li]:text-slate-700 dark:[&_li]:text-slate-300
-                         [&_a]:text-blue-600 [&_a]:hover:text-blue-700 [&_a]:underline [&_a]:decoration-blue-300 [&_a]:underline-offset-2 dark:[&_a]:text-blue-400 dark:[&_a]:hover:text-blue-300
-                         [&_code]:bg-slate-100 [&_code]:dark:bg-slate-800 [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:rounded-md [&_code]:text-sm [&_code]:font-mono [&_code]:text-slate-900 dark:[&_code]:text-slate-100
-                         [&_pre]:bg-slate-900 dark:[&_pre]:bg-slate-950 [&_pre]:p-4 [&_pre]:rounded-xl [&_pre]:overflow-x-auto
-                         [&_pre]:font-mono [&_pre]:text-sm [&_pre]:leading-6
-                         [&_pre_code]:block [&_pre_code]:whitespace-pre [&_pre_code]:bg-transparent [&_pre_code]:p-0
-                         [&_blockquote]:border-l-4 [&_blockquote]:border-blue-500 [&_blockquote]:pl-4 [&_blockquote]:italic [&_blockquote]:text-slate-600 dark:[&_blockquote]:text-slate-400 [&_blockquote]:my-4
-                         [&_strong]:font-bold [&_strong]:text-slate-900 dark:[&_strong]:text-white
-                         [&_em]:italic
-                         [&_table]:w-full [&_table]:my-6 [&_table]:border-collapse
-                         [&_thead]:bg-slate-100 dark:[&_thead]:bg-slate-800
-                         [&_th]:px-4 [&_th]:py-3 [&_th]:font-bold [&_th]:text-left [&_th]:border-b-2 [&_th]:border-slate-300 dark:[&_th]:border-slate-600 [&_th]:text-slate-900 dark:[&_th]:text-white
-                         [&_td]:px-4 [&_td]:py-3 [&_td]:border-b [&_td]:border-slate-200 dark:[&_td]:border-slate-700 [&_td]:text-slate-700 dark:[&_td]:text-slate-300
-                         [&_tr:hover]:bg-slate-50 dark:[&_tr:hover]:bg-slate-800/50
-                         [&_hr]:my-8 [&_hr]:border-slate-300 dark:[&_hr]:border-slate-700
-                         [&_img]:rounded-xl [&_img]:shadow-lg
-                         [&_span[data-math-style='display']]:block [&_span[data-math-style='display']]:my-6 [&_span[data-math-style='display']]:text-center [&_span[data-math-style='display']]:text-lg [&_span[data-math-style='display']]:font-serif [&_span[data-math-style='display']]:italic [&_span[data-math-style='display']]:text-slate-800 dark:[&_span[data-math-style='display']]:text-slate-200
-                         [&_span[data-math-style='inline']]:font-serif [&_span[data-math-style='inline']]:italic [&_span[data-math-style='inline']]:text-slate-800 dark:[&_span[data-math-style='inline']]:text-slate-200 [&_span[data-math-style='inline']]:mx-0.5"}>
-              {Phoenix.HTML.raw(@html)}
-            </div>
-          <% end %>
-        </div>
-      </div>
-    </div>
-    """
-  end
-end
-
-defmodule ChunksPanel do
-  use Phoenix.LiveComponent
-
-  def render(assigns) do
-    ~H"""
-    <div class="bg-white/70 dark:bg-slate-900/70 backdrop-blur-xl rounded-2xl shadow-xl border border-slate-200/50 dark:border-slate-800/50 overflow-hidden">
-      <div class="px-6 py-4 bg-gradient-to-r from-slate-50 to-white dark:from-slate-900 dark:to-slate-800/50 border-b border-slate-200 dark:border-slate-700/50">
-        <h3 class="text-base font-bold text-slate-900 dark:text-white">Markdown Chunks</h3>
-      </div>
-      <div class="p-6">
-        <div id="chunks-container" class="max-h-[50vh] overflow-y-auto">
-          <%= if @chunks == [] do %>
-            <div class="text-slate-500 dark:text-slate-400 text-center py-12">
-              No chunks yet
-            </div>
-          <% else %>
-            <div class="flex flex-wrap gap-1">
-              <%= for chunk <- @chunks do %>
-                <span class="inline-flex items-center bg-gradient-to-br from-blue-50 to-blue-100 dark:from-blue-900/30 dark:to-blue-800/30 border border-blue-200 dark:border-blue-700/50 rounded-lg text-xs text-slate-700 dark:text-blue-300 font-mono px-2 py-1.5 shadow-sm"><%= String.slice(inspect(chunk), 1..-2//1) %></span>
-              <% end %>
-            </div>
-          <% end %>
-        </div>
-      </div>
-    </div>
-    """
-  end
-end
-
-defmodule StreamingDemo do
+defmodule MDExStreamingDemo do
   use Phoenix.LiveView
+
+  @default_url "https://raw.githubusercontent.com/leandrocp/mdex/main/README.md"
+  @display_chunk_bytes 64
+  @max_body_bytes 2_000_000
 
   @mdex_options [
     extension: [
@@ -148,434 +25,515 @@ defmodule StreamingDemo do
       shortcodes: true,
       strikethrough: true,
       table: true,
-      tagfilter: true,
-      tasklist: true,
-      math_dollars: true
+      tasklist: true
     ],
-    parse: [
-      relaxed_autolinks: true,
-      relaxed_tasklist_matching: true
-    ],
-    render: [
-      github_pre_lang: true,
-      full_info_string: true,
-      unsafe: true
-    ],
-    syntax_highlight: [formatter: {:html_inline, theme: "github_light"}],
-    streaming: true
+    parse: [relaxed_autolinks: true, relaxed_tasklist_matching: true],
+    syntax_highlight: [
+      engine: :lumis,
+      opts: [
+        formatter: {:html_multi_themes, themes: [light: "github_light", dark: "github_dark"], default_theme: "light-dark()"}
+      ]
+    ]
   ]
 
-  def mount(_params, _session, socket) do
+  @pipeline_markdown """
+  ```elixir
+  Req.get!(url, into: :self).body
+  |> MDEx.stream(options)
+  |> Enum.each(&send(live_view, {:markdown_chunk, &1}))
+
+  # In the LiveView process:
+  stream_insert(socket, :markdown, chunk)
+  ```
+  """
+
+  @impl Phoenix.LiveView
+  def mount(params, _session, socket) do
+    url = Map.get(params, "url", @default_url)
+    live_view_memory = process_memory()
+
     {:ok,
-     assign(socket,
-       document: MDEx.new(@mdex_options),
-       chunks: [],
-       html: "",
-       streaming: false,
-       speed: 80,
-       current_chunk: 0,
-       total_chunks: 0,
-       stream_ref: nil
+     socket
+     |> stream_configure(:markdown, dom_id: fn {id, _document} -> "markdown-#{id}" end)
+     |> stream(:markdown, [])
+     |> assign(
+       url: url,
+       delay_ms: 25,
+       auto_scroll: true,
+       status: :idle,
+       error: nil,
+       run_id: nil,
+       received_bytes: 0,
+       received_chunks: 0,
+       markdown_updates: 0,
+       rendered_chunks: 0,
+       producer_memory: 0,
+       producer_peak_memory: 0,
+       live_view_memory: live_view_memory,
+       live_view_peak_memory: live_view_memory,
+       display_chunk_bytes: @display_chunk_bytes,
+       pipeline_html: MDEx.to_html!(@pipeline_markdown, @mdex_options)
      )}
   end
 
+  @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
-    <div class="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/20 to-slate-100 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950">
-      <div class="max-w-7xl mx-auto px-6 py-12">
-        <!-- Header -->
-        <div class="text-center mb-8">
-          <h1 class="text-4xl md:text-5xl font-bold tracking-tight bg-gradient-to-r from-slate-900 via-blue-900 to-slate-900 dark:from-white dark:via-blue-400 dark:to-white bg-clip-text text-transparent">
-            MDEx Streaming
-          </h1>
-        </div>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
 
-        <!-- Controls -->
-        <div class="mb-8">
-          <div class="bg-white/70 dark:bg-slate-900/70 backdrop-blur-xl rounded-2xl shadow-xl border border-slate-200/50 dark:border-slate-800/50 p-5">
-            <div class="flex items-center gap-6 flex-wrap">
-              <!-- Demo Actions -->
-              <div class="flex gap-3">
-                <button phx-click="start_demo" class="px-6 py-2.5 text-sm font-semibold text-white bg-gradient-to-r from-blue-600 to-blue-500 hover:from-blue-700 hover:to-blue-600 rounded-xl shadow-lg shadow-blue-500/25 transition-all disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none" disabled={@streaming}>
-                  Start
-                </button>
-                <button phx-click="clear" class="px-6 py-2.5 text-sm font-semibold text-slate-700 dark:text-slate-300 bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 rounded-xl transition-all">
-                  Clear
-                </button>
-              </div>
+      body { margin: 0; background: #f5f7fb; color: #172033; }
+      * { box-sizing: border-box; }
+      button, input { font: inherit; }
+      code { font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace; }
 
-              <!-- Speed Control -->
-              <div class="flex items-center gap-4 flex-1 min-w-[240px]">
-                <label class="text-sm font-semibold text-slate-700 dark:text-slate-300 whitespace-nowrap">
-                  Speed
-                </label>
-                <form phx-change="update_speed" class="flex-1">
-                  <input
-                    type="range"
-                    name="speed"
-                    min="1"
-                    max="1000"
-                    step="1"
-                    value={1001 - @speed}
-                    disabled={@streaming}
-                    class="w-full h-2 bg-slate-200 dark:bg-slate-700 rounded-full appearance-none cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-blue-600 [&::-webkit-slider-thumb]:cursor-pointer"
-                  />
-                </form>
-                <span class="text-sm font-mono font-semibold text-slate-700 dark:text-slate-300 bg-slate-100 dark:bg-slate-800 px-3 py-1.5 rounded-lg whitespace-nowrap">
-                  <%= @speed %>ms
-                </span>
-              </div>
+      .page { min-height: 100vh; padding: 2rem 1rem 4rem; }
+      .shell { width: min(1040px, 100%); margin: 0 auto; }
+      .hero { margin-bottom: 1.25rem; }
+      .hero h1 { margin: 0 0 .4rem; font-size: clamp(2rem, 5vw, 3.5rem); letter-spacing: -.05em; }
+      .hero p { margin: 0; color: #5d667a; font-size: 1.05rem; }
 
-              <!-- Progress -->
-              <div class="flex items-center gap-3">
-                <%= if @total_chunks == 0 do %>
-                  <span class="text-xs font-semibold text-slate-500 dark:text-slate-400 bg-slate-100 dark:bg-slate-800 px-3 py-1.5 rounded-full">
-                    Waiting
-                  </span>
-                  <span class="text-sm font-mono font-semibold text-slate-600 dark:text-slate-400 bg-slate-100 dark:bg-slate-800 px-3 py-1.5 rounded-lg">
-                    - / -
-                  </span>
-                <% else %>
-                  <span :if={@streaming} class="text-xs font-semibold text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/30 px-3 py-1.5 rounded-full animate-pulse">
-                    Streaming
-                  </span>
-                  <span class="text-sm font-mono font-semibold text-slate-700 dark:text-slate-300 bg-slate-100 dark:bg-slate-800 px-3 py-1.5 rounded-lg">
-                    <%= @current_chunk %> / <%= @total_chunks %>
-                  </span>
-                <% end %>
-              </div>
-            </div>
+      .card { background: #fff; border: 1px solid #dfe4ee; border-radius: 16px; box-shadow: 0 14px 40px rgba(25, 38, 71, .08); }
+      .controls { padding: 1rem; margin-bottom: 1rem; }
+      .url-form { display: grid; grid-template-columns: 1fr auto auto; gap: .65rem; }
+      .url-input { width: 100%; min-width: 0; border: 1px solid #cbd3e1; border-radius: 10px; padding: .72rem .85rem; background: #fff; color: #172033; }
+      .button { border: 0; border-radius: 10px; padding: .72rem 1rem; cursor: pointer; font-weight: 700; }
+      .button-primary { color: #fff; background: #4f46e5; }
+      .button-secondary { color: #313a4d; background: #e9edf5; }
+      .button[disabled] { cursor: not-allowed; opacity: .5; }
+
+      .pace { display: grid; grid-template-columns: auto 1fr auto; align-items: center; gap: .8rem; margin-top: 1rem; }
+      .pace label { color: #465066; font-weight: 650; }
+      .pace input[type="range"] { width: 100%; accent-color: #4f46e5; }
+      .pace output { min-width: 7.5rem; text-align: right; color: #465066; font-variant-numeric: tabular-nums; }
+      .auto-scroll { grid-column: 1 / -1; display: inline-flex; align-items: center; gap: .55rem; width: fit-content; cursor: pointer; }
+      .auto-scroll input { width: 1rem; height: 1rem; accent-color: #4f46e5; }
+
+      .telemetry { margin-bottom: 1rem; padding: 1rem; color: #5d667a; }
+      .status { display: flex; flex-wrap: wrap; gap: .5rem 1rem; align-items: center; font-size: .9rem; }
+      .status strong { color: #172033; }
+      .status-dot { width: .55rem; height: .55rem; border-radius: 50%; background: #98a2b4; }
+      .status-dot.streaming { background: #16a34a; box-shadow: 0 0 0 .3rem rgba(22, 163, 74, .13); animation: pulse 1.2s infinite; }
+      .status-dot.complete { background: #4f46e5; }
+      .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: .7rem; margin: 1rem 0 0; }
+      .metric { min-width: 0; padding: .75rem; border: 1px solid #e3e7ef; border-radius: 10px; background: #f8f9fc; }
+      .metric dt { margin-bottom: .25rem; color: #737d90; font-size: .72rem; font-weight: 750; letter-spacing: .07em; text-transform: uppercase; }
+      .metric dd { margin: 0; color: #172033; font-size: 1rem; font-weight: 750; font-variant-numeric: tabular-nums; }
+      .metric small { display: block; margin-top: .18rem; color: #737d90; font-size: .75rem; }
+      .metrics-note { margin: .8rem 0 0; font-size: .78rem; }
+      .error { padding: .8rem 1rem; margin-bottom: 1rem; border: 1px solid #fecaca; border-radius: 12px; background: #fef2f2; color: #991b1b; }
+
+      .output { padding: clamp(1.1rem, 4vw, 2.5rem); min-height: 24rem; overflow-wrap: anywhere; }
+      .empty { display: grid; place-items: center; min-height: 20rem; color: #7a8498; text-align: center; }
+      .markdown-chunk { display: contents; }
+      .markdown-body { line-height: 1.7; }
+      .markdown-body h1, .markdown-body h2, .markdown-body h3 { line-height: 1.25; letter-spacing: -.025em; margin: 1.5em 0 .55em; }
+      .markdown-body h1:first-child, .markdown-body h2:first-child { margin-top: 0; }
+      .markdown-body a { color: #4338ca; }
+      .markdown-body img { max-width: 100%; }
+      .markdown-body blockquote { margin-left: 0; padding-left: 1rem; border-left: 4px solid #a5b4fc; color: #566078; }
+      .markdown-body code { padding: .12rem .35rem; border-radius: 5px; background: #eef1f7; }
+      .markdown-body pre { overflow-x: auto; padding: 1rem; border-radius: 10px; background: #111827; color: #e5e7eb; }
+      .markdown-body pre code { padding: 0; background: transparent; }
+      .markdown-body table { display: block; max-width: 100%; overflow-x: auto; border-collapse: collapse; }
+      .markdown-body th, .markdown-body td { padding: .5rem .7rem; border: 1px solid #d7dce6; text-align: left; }
+      .markdown-body hr { margin: 2rem 0; border: 0; border-top: 1px solid #d7dce6; }
+
+      .how-it-works { margin-top: 1rem; padding: 1.25rem; color: #5d667a; }
+      .how-it-works h2 { margin: 0; color: #313a4d; font-size: 1.2rem; }
+      .how-it-works p { margin: .35rem 0 1rem; }
+      .how-it-works pre { overflow-x: auto; margin: 0; }
+
+      @keyframes pulse { 50% { opacity: .55; } }
+
+      @media (max-width: 720px) {
+        .url-form { grid-template-columns: 1fr auto; }
+        .url-input { grid-column: 1 / -1; }
+        .pace { grid-template-columns: 1fr auto; }
+        .pace label { grid-column: 1 / -1; }
+      }
+
+      @media (prefers-color-scheme: dark) {
+        body { background: #0d1320; color: #e7eaf0; }
+        .hero p, .telemetry, .pace label, .pace output, .how-it-works { color: #aeb6c7; }
+        .card { background: #151d2c; border-color: #2a3447; box-shadow: none; }
+        .url-input { background: #0f1726; border-color: #354057; color: #e7eaf0; }
+        .button-secondary { color: #d8dce5; background: #2a3447; }
+        .status strong, .metric dd, .how-it-works h2 { color: #e7eaf0; }
+        .metric { border-color: #303b50; background: #101827; }
+        .metric dt, .metric small { color: #98a3b7; }
+        .error { border-color: #7f1d1d; background: #3b1118; color: #fecaca; }
+        .markdown-body a { color: #a5b4fc; }
+        .markdown-body blockquote { color: #b5bdcd; }
+        .markdown-body code { background: #273145; }
+        .markdown-body th, .markdown-body td { border-color: #3a4559; }
+        .markdown-body hr { border-color: #3a4559; }
+        .empty { color: #8f99ac; }
+      }
+    </style>
+
+    <main class="page">
+      <div class="shell">
+        <header class="hero">
+          <h1>MDEx streaming playground</h1>
+          <p>Stream a remote Markdown document through Req, MDEx, and Phoenix LiveView.</p>
+        </header>
+
+        <section class="card controls">
+          <form id="url-form" phx-submit="start" class="url-form">
+            <input
+              class="url-input"
+              type="url"
+              name="url"
+              value={@url}
+              aria-label="Markdown URL"
+              placeholder="https://example.com/document.md"
+              required
+            />
+            <button class="button button-primary" type="submit">
+              {if @status == :streaming, do: "Restart", else: "Stream URL"}
+            </button>
+            <button
+              class="button button-secondary"
+              type="button"
+              phx-click="stop"
+              disabled={@status != :streaming}
+            >
+              Stop
+            </button>
+          </form>
+
+          <form id="pace-form" phx-change="pace" class="pace">
+            <label for="delay-ms">Playback delay per {@display_chunk_bytes}-byte chunk</label>
+            <input
+              id="delay-ms"
+              type="range"
+              name="delay_ms"
+              min="0"
+              max="1000"
+              step="10"
+              value={@delay_ms}
+            />
+            <output for="delay-ms">{@delay_ms} ms</output>
+            <label class="auto-scroll" for="auto-scroll">
+              <input type="hidden" name="auto_scroll" value="false" />
+              <input
+                id="auto-scroll"
+                type="checkbox"
+                name="auto_scroll"
+                value="true"
+                checked={@auto_scroll}
+              />
+              Auto-scroll as chunks arrive
+            </label>
+          </form>
+        </section>
+
+        <section id="stream-metrics" class="card telemetry" aria-live="polite">
+          <div class="status">
+            <span class={["status-dot", Atom.to_string(@status)]}></span>
+            <strong>{status_label(@status)}</strong>
+            <span>Run data</span>
           </div>
+
+          <dl class="metrics">
+            <div class="metric">
+              <dt>Req source</dt>
+              <dd id="source-metrics">{format_bytes(@received_bytes)}</dd>
+              <small>{@received_chunks} chunks · paced at {@display_chunk_bytes} bytes</small>
+            </div>
+            <div class="metric">
+              <dt>MDEx</dt>
+              <dd id="mdex-metrics">{@markdown_updates} updates</dd>
+              <small>{max(@markdown_updates - @rendered_chunks, 0)} replacements</small>
+            </div>
+            <div class="metric">
+              <dt>LiveView DOM</dt>
+              <dd id="dom-metrics">{@rendered_chunks} chunks</dd>
+              <small>
+                {stable_chunks(@status, @rendered_chunks)} stable · {mutable_chunks(@status, @rendered_chunks)} open
+              </small>
+            </div>
+            <div class="metric">
+              <dt>Producer memory</dt>
+              <dd id="producer-memory">{format_bytes(@producer_memory)}</dd>
+              <small>peak {format_bytes(@producer_peak_memory)}</small>
+            </div>
+            <div class="metric">
+              <dt>LiveView memory</dt>
+              <dd id="live-view-memory">{format_bytes(@live_view_memory)}</dd>
+              <small>peak {format_bytes(@live_view_peak_memory)}</small>
+            </div>
+          </dl>
+
+          <p class="metrics-note">
+            Memory is measured for each BEAM process. The browser keeps stable chunks. MDEx keeps only the source that may still change.
+          </p>
+        </section>
+
+        <div :if={@error} class="error" role="alert">{@error}</div>
+
+        <div :if={@status == :idle} class="card empty">
+          <p>Press <strong>Stream URL</strong> to fetch the MDEx README, or enter another Markdown URL.</p>
         </div>
 
-        <!-- Panels -->
-        <div class="space-y-6">
-          <.live_component module={RenderPanel} id="render-panel" html={@html} />
-          <.live_component module={ChunksPanel} id="chunks-panel" chunks={Enum.take(@chunks, @current_chunk)} />
-        </div>
+        <article
+          :if={@status != :idle}
+          id="markdown-output"
+          class="card output markdown-body"
+          phx-update="stream"
+          phx-hook="AutoScroll"
+          data-auto-scroll={to_string(@auto_scroll)}
+        >
+          <div
+            :for={{dom_id, {_id, document}} <- @streams.markdown}
+            id={dom_id}
+            class="markdown-chunk"
+          >
+            {Phoenix.HTML.raw(MDEx.to_html!(document))}
+          </div>
+        </article>
+
+        <section id="how-it-works" class="card how-it-works">
+          <h2>How it works</h2>
+          <p>Req reads the source. MDEx parses each chunk. LiveView updates the matching DOM child.</p>
+          <div class="markdown-body">{Phoenix.HTML.raw(@pipeline_html)}</div>
+        </section>
       </div>
-    </div>
+    </main>
+
+    <script phx-no-curly-interpolation>
+      window.hooks.AutoScroll = {
+        mounted() { this.scrollToLatest() },
+        updated() { this.scrollToLatest() },
+        scrollToLatest() {
+          if (this.el.dataset.autoScroll === "true") {
+            window.requestAnimationFrame(() => {
+              window.scrollTo({ top: document.documentElement.scrollHeight, behavior: "smooth" })
+            })
+          }
+        }
+      }
+    </script>
     """
   end
 
-  def handle_event("start_demo", _params, socket) do
-    content = """
-    # Streaming Music App with Phoenix LiveView
+  @impl Phoenix.LiveView
+  def handle_event("pace", params, socket) do
+    {:noreply,
+     assign(socket,
+       delay_ms: parse_delay(params["delay_ms"]),
+       auto_scroll: params["auto_scroll"] == "true"
+     )}
+  end
 
-    :rocket: Launch a collaborative listening room with real-time diffs driven by `Phoenix LiveView`.
+  def handle_event("start", %{"url" => raw_url}, socket) do
+    url = String.trim(raw_url)
 
-    ## Why LiveView Fits
+    case validate_url(url) do
+      :ok ->
+        live_view = self()
+        live_view_memory = process_memory()
+        run_id = make_ref()
 
-    Phoenix LiveView keeps the render pipeline on the server, letting state changes push efficient patches into the session. This means listeners enjoy responsive updates without custom JavaScript, yet you retain declarative Elixir code.
+        socket =
+          socket
+          |> cancel_async(:markdown_fetch)
+          |> stream(:markdown, [], reset: true)
+          |> assign(
+            url: url,
+            run_id: run_id,
+            status: :streaming,
+            error: nil,
+            received_bytes: 0,
+            received_chunks: 0,
+            markdown_updates: 0,
+            rendered_chunks: 0,
+            producer_memory: 0,
+            producer_peak_memory: 0,
+            live_view_memory: live_view_memory,
+            live_view_peak_memory: live_view_memory
+          )
+          |> start_async(:markdown_fetch, fn -> stream_url(url, live_view, run_id) end)
 
-    ### Experience Goals
+        {:noreply, socket}
 
-    - :notes: Seamless streaming controls
-    - :headphones: Shared queue awareness
-    - :sparkles: Animated feedback without page reload
-    - :musical_keyboard: Keyboard shortcuts for power users
-
-    ## Task Board
-
-    - [x] Initialize project scaffolding
-    - [ ] Wire up LiveView routes
-      - [x] Create router
-      - [ ] Add authentication
-    - [ ] Connect to the audio backend
-    - [ ] Style the listening room
-    - [ ] Publish real-time metrics dashboard
-
-    ## Architecture Snapshot
-
-    | Layer | Responsibility | LiveView Hook |
-    | --- | --- | --- |
-    | LiveView | Stateful UI process | mount / handle_event |
-    | PubSub | Broadcast track events | Phoenix.PubSub |
-    | Context | Business logic | StreamMusic.Library |
-    | Presence | Listener roster tracking | Phoenix.Presence |
-    | Data | Persistent playlists | Ecto schemas |
-
-    ## Setup Command
-
-    ```bash
-    mix phx.new stream_music --live
-    cd stream_music
-    mix deps.get
-    ```
-
-    ## LiveView Outline
-
-    ```elixir
-    defmodule StreamMusicWeb.PlayerLive do
-      use StreamMusicWeb, :live_view
-      alias Phoenix.PubSub
-
-      @topic "stream_music:queue"
-
-      def mount(_params, _session, socket) do
-        if connected?(socket) do
-          Phoenix.PubSub.subscribe(StreamMusic.PubSub, @topic)
-        end
-        {:ok, assign(socket, playlist: [], now_playing: nil, search: "", volume: 60, listeners: %{})}
-      end
-
-      def handle_event("search", %{"query" => query}, socket) do
-        {:noreply, assign(socket, search: query)}
-      end
-
-      def handle_event("queue", %{"track" => track}, socket) do
-        Phoenix.PubSub.broadcast(StreamMusic.PubSub, @topic, {:queue, track})
-        {:noreply, update(socket, :playlist, fn list -> list ++ [track] end)}
-      end
-
-      def handle_event("play", %{"track" => track}, socket) do
-        Phoenix.PubSub.broadcast(StreamMusic.PubSub, @topic, {:play, track})
-        {:noreply, assign(socket, now_playing: track)}
-      end
-
-      def handle_info({:queue, track}, socket) do
-        {:noreply, update(socket, :playlist, fn list -> list ++ [track] end)}
-      end
-
-      def handle_info({:play, track}, socket) do
-        {:noreply, assign(socket, now_playing: track)}
-      end
+      {:error, message} ->
+        {:noreply, assign(socket, error: message, status: :error)}
     end
-    ```
-
-    ### Progressive Streaming
-
-    LiveViews start with a static render before upgrading to the persistent connection, so first meaningful paint stays fast while future updates travel over a single channel.
-
-    ### Performance Metrics
-
-    The connection latency can be modeled as:
-
-    $$
-    L = \\frac{RTT}{2} + P_{server}
-    $$
-
-    Where $L$ is total latency, $RTT$ is round-trip time, and $P_{server}$ is server processing time.
-
-    For optimal user experience, aim for $L < 100ms$ to maintain the illusion of instantaneous updates.
-
-    ## Interaction Flow
-
-    1. Visitor opens the lobby and receives the rendered `PlayerLive`.
-    2. `mount/3` seeds assigns with playlist snapshots.
-    3. Track searches call `handle_event/3` to refine results.
-    4. Queue updates broadcast through PubSub and hydrate everyone.
-    5. Presence diff pushes listener join or leave events.
-
-    ### Playlist Signals
-
-    - **Now Playing**: highlight the active track and waveform
-    - **Queue**: show pending entries with avatars
-    - **History**: list completed tracks for replay fans
-
-    ### Commands for Library Context
-
-    Run the generator to scaffold data boundaries:
-
-    - `mix phx.gen.live Library Track tracks title:string artist:string duration:integer source_url:string`
-    - `mix phx.gen.schema Library.Room rooms slug:string theme:string description:text`
-
-    ### Queue Feedback
-
-    | Event | LiveView Callback | Outcome |
-    | --- | --- | --- |
-    | :mag: Search query | `handle_event "search"` | Update suggestions |
-    | :heavy_plus_sign: Queue track | `handle_event "queue"` | Append playlist |
-    | :arrow_forward: Play track | `handle_event "play"` | Change headline state |
-    | :busts_in_silhouette: Presence diff | `handle_info {:presence_diff, diff}` | Refresh listener list |
-    | :checkered_flag: Track finished | `handle_info {:playback_done, track}` | Rotate playlist |
-
-    ### Listener Journey
-
-    - Enter lobby and see :headphones: welcome banner
-    - Use instant search to find a favorite song
-    - Add the track to the collaborative queue
-    - Watch :rocket: transitions as the now playing card updates
-    - React with inline emoji to celebrate the vibe
-    - Share with friends via <hello@example.com> or https://streammusic.app
-
-    ![App Screenshot](https://placehold.co/600x300/6366f1/white?text=Stream+Music+App)
-
-    ## Real-Time Considerations
-
-    > **Important**: Keep these best practices in mind when building real-time features.
-    >
-    > Performance is critical for user experience in collaborative apps.
-
-    - Keep assigns minimal to avoid large diffs
-    - Stream lists with `Phoenix.LiveView.stream/4` for scalable queues
-    - Push events with `push_event/3` for waveform animations
-    - Use `temporary_assigns` to discard transient payloads
-    - ~~Avoid polling~~ Use LiveView for real-time updates
-    - Balance updates between server broadcasts and client hooks
-
-    ### Client Integration
-
-    ```javascript
-    // Subscribe to live updates
-    const socket = new Socket("/socket", {params: {token: userToken}})
-    socket.connect()
-
-    const channel = socket.channel("room:lobby", {})
-    channel.join()
-      .receive("ok", resp => { console.log("Joined successfully", resp) })
-      .receive("error", resp => { console.log("Unable to join", resp) })
-
-    channel.on("new_track", payload => {
-      updateNowPlaying(payload.track)
-    })
-    ```
-
-    ### Deployment Notes
-
-    :package: Infrastructure Requirements
-
-    - Configure [CDN edge caching](https://docs.example.com/cdn) for artwork
-    - Enable `live_session` routes for authentication
-    - Tune WebSocket pool size for expected rooms
-    - Leverage clustered nodes for resilient PubSub
-
-    <p>
-      <small class="text-blue-600 dark:text-blue-300 font-medium">
-        💡 Pro Tip: Start with a single node and scale horizontally as your user base grows.
-        Monitor metrics at https://metrics.streammusic.app
-      </small>
-    </p>
-
-    ## Next Steps
-
-    1. Finalize UI polish in Tailwind components
-    2. Integrate payment tiers for premium rooms
-    3. Add offline fallbacks when connection drops
-    4. Extend analytics pipeline for retention insights
-
-    ## Celebration
-
-    Wrap the launch with :tada: playlists and a :musical_note: release party!
-
-    ---
-
-    *Built with :purple_heart: using [Elixir](https://elixir-lang.org) and [MDEx](https://hex.pm/packages/mdex)*
-    """
-
-    chunks = chunk_for_ai_streaming(content)
-    simulate_streaming(socket, chunks)
   end
 
-  def handle_event("clear", _params, socket) do
-    socket
-    |> assign(
-      document: MDEx.new(@mdex_options),
-      chunks: [],
-      html: "",
-      streaming: false,
-      current_chunk: 0,
-      total_chunks: 0,
-      stream_ref: nil
-    )
-    |> then(&{:noreply, &1})
+  def handle_event("stop", _params, socket) do
+    {:noreply,
+     socket
+     |> cancel_async(:markdown_fetch)
+     |> assign(status: :stopped, run_id: nil)}
   end
 
-  def handle_event("update_speed", %{"speed" => speed}, socket) do
-    actual_speed = 1001 - String.to_integer(speed)
-    {:noreply, assign(socket, :speed, actual_speed)}
+  @impl Phoenix.LiveView
+  def handle_info(
+        {:pace_chunk, run_id, producer, bytes, producer_memory},
+        %{assigns: %{run_id: run_id}} = socket
+      ) do
+    send(producer, {:continue, run_id, socket.assigns.delay_ms})
+
+    {:noreply,
+     socket
+     |> update(:received_bytes, &(&1 + bytes))
+     |> update(:received_chunks, &(&1 + 1))
+     |> put_memory(:producer, producer_memory)
+     |> put_memory(:live_view, process_memory())}
   end
 
-  def handle_info({:stream_chunk, ref, chunk}, %{assigns: %{stream_ref: ref}} = socket) do
-    document = Enum.into([chunk], socket.assigns.document)
-    html = html_from(document)
+  def handle_info({:pace_chunk, _run_id, _producer, _bytes, _memory}, socket), do: {:noreply, socket}
 
-    socket =
-      socket
-      |> update(:chunks, fn chunks -> chunks ++ [chunk] end)
-      |> assign(:document, document)
-      |> assign(:html, html)
-      |> update(:current_chunk, &(&1 + 1))
-
-    {:noreply, socket}
+  def handle_info(
+        {:markdown_chunk, run_id, {id, _document} = chunk, producer_memory},
+        %{assigns: %{run_id: run_id}} = socket
+      ) do
+    {:noreply,
+     socket
+     |> stream_insert(:markdown, chunk)
+     |> update(:markdown_updates, &(&1 + 1))
+     |> update(:rendered_chunks, &max(&1, id + 1))
+     |> put_memory(:producer, producer_memory)
+     |> put_memory(:live_view, process_memory())}
   end
 
-  def handle_info({:stream_chunk, _ref, _chunk}, socket), do: {:noreply, socket}
+  def handle_info({:markdown_chunk, _run_id, _chunk, _memory}, socket), do: {:noreply, socket}
 
-  def handle_info({:streaming_complete, ref}, %{assigns: %{stream_ref: ref}} = socket) do
-    {:noreply, assign(socket, :streaming, false)}
+  @impl Phoenix.LiveView
+  def handle_async(:markdown_fetch, {:ok, {run_id, _status}}, %{assigns: %{run_id: run_id}} = socket) do
+    {:noreply, assign(socket, status: :complete, run_id: nil)}
   end
 
-  def handle_info({:streaming_complete, _ref}, socket), do: {:noreply, socket}
+  def handle_async(:markdown_fetch, {:ok, {_run_id, _status}}, socket), do: {:noreply, socket}
 
-  defp simulate_streaming(socket, chunks) do
-    speed = socket.assigns.speed
-    total_chunks = Enum.count(chunks)
-    stream_ref = make_ref()
-    parent = self()
+  def handle_async(:markdown_fetch, {:exit, {:shutdown, :cancel}}, socket), do: {:noreply, socket}
 
-    Task.start(fn ->
-      chunks
-      |> Stream.each(fn chunk ->
-        Process.sleep(speed)
-        send(parent, {:stream_chunk, stream_ref, chunk})
-      end)
-      |> Stream.run()
+  def handle_async(:markdown_fetch, {:exit, reason}, socket) do
+    {:noreply, assign(socket, status: :error, run_id: nil, error: exception_message(reason))}
+  end
 
-      send(parent, {:streaming_complete, stream_ref})
+  defp stream_url(url, live_view, run_id) do
+    response = Req.get!(url, into: :self, raw: true, redirect: true)
+
+    unless response.status in 200..299 do
+      Req.cancel_async_response(response)
+      raise "request returned HTTP #{response.status}"
+    end
+
+    response.body
+    |> rechunk(@display_chunk_bytes)
+    |> enforce_body_limit()
+    |> pace_with_live_view(live_view, run_id)
+    |> MDEx.stream(@mdex_options)
+    |> Enum.each(fn chunk ->
+      send(live_view, {:markdown_chunk, run_id, chunk, process_memory()})
     end)
 
-    updated_socket =
-      assign(socket, %{
-        document: MDEx.new(@mdex_options),
-        chunks: [],
-        html: "",
-        streaming: true,
-        speed: speed,
-        current_chunk: 0,
-        total_chunks: total_chunks,
-        stream_ref: stream_ref
-      })
-
-    {:noreply, updated_socket}
+    {run_id, response.status}
   end
 
-  defp html_from(%MDEx.Document{} = document), do: MDEx.to_html!(document, @mdex_options)
-
-  defp chunk_for_ai_streaming(text) do
-    text
-    |> String.graphemes()
-    |> do_random_chunk([])
+  defp rechunk(chunks, bytes) do
+    Stream.flat_map(chunks, &split_binary(&1, bytes, []))
   end
 
-  defp do_random_chunk([], acc), do: Enum.reverse(acc)
+  defp split_binary("", _bytes, chunks), do: Enum.reverse(chunks)
 
-  defp do_random_chunk(graphemes, acc) do
-    chunk_size = Enum.random(3..20)
-    {chunk, rest} = Enum.split(graphemes, chunk_size)
+  defp split_binary(binary, bytes, chunks) when byte_size(binary) <= bytes do
+    Enum.reverse([binary | chunks])
+  end
 
-    case chunk do
-      [] -> Enum.reverse(acc)
-      _ -> do_random_chunk(rest, [Enum.join(chunk) | acc])
+  defp split_binary(binary, bytes, chunks) do
+    <<chunk::binary-size(^bytes), rest::binary>> = binary
+    split_binary(rest, bytes, [chunk | chunks])
+  end
+
+  defp enforce_body_limit(chunks) do
+    Stream.transform(chunks, 0, fn chunk, total ->
+      total = total + byte_size(chunk)
+
+      if total > @max_body_bytes do
+        raise "response exceeded the #{div(@max_body_bytes, 1_000_000)} MB demo limit"
+      end
+
+      {[chunk], total}
+    end)
+  end
+
+  defp pace_with_live_view(chunks, live_view, run_id) do
+    Stream.map(chunks, fn chunk ->
+      send(live_view, {:pace_chunk, run_id, self(), byte_size(chunk), process_memory()})
+
+      receive do
+        {:continue, ^run_id, delay_ms} -> Process.sleep(delay_ms)
+      after
+        5_000 -> raise "LiveView did not acknowledge the source chunk"
+      end
+
+      chunk
+    end)
+  end
+
+  defp validate_url(url) do
+    case URI.new(url) do
+      {:ok, %URI{scheme: scheme, host: host}} when scheme in ["http", "https"] and is_binary(host) -> :ok
+      _ -> {:error, "Enter an absolute http:// or https:// URL."}
     end
   end
-end
 
-defmodule DemoRouter do
-  use Phoenix.Router
-  import Phoenix.LiveView.Router
-
-  pipeline :browser do
-    plug(:accepts, ["html"])
-    plug(:fetch_session)
-    plug(:put_root_layout, html: {DemoLayout, :root})
-    plug(:put_secure_browser_headers)
+  defp parse_delay(value) do
+    value
+    |> String.to_integer()
+    |> min(1000)
+    |> max(0)
+  rescue
+    ArgumentError -> 25
   end
 
-  scope "/" do
-    pipe_through(:browser)
-    live("/", StreamingDemo)
+  defp status_label(:idle), do: "Ready"
+  defp status_label(:streaming), do: "Streaming"
+  defp status_label(:complete), do: "Complete"
+  defp status_label(:stopped), do: "Stopped"
+  defp status_label(:error), do: "Error"
+
+  defp stable_chunks(status, chunks), do: chunks - mutable_chunks(status, chunks)
+
+  defp mutable_chunks(:complete, _chunks), do: 0
+  defp mutable_chunks(_status, 0), do: 0
+  defp mutable_chunks(_status, _chunks), do: 1
+
+  defp put_memory(socket, :producer, bytes) do
+    socket
+    |> assign(:producer_memory, bytes)
+    |> update(:producer_peak_memory, &max(&1, bytes))
   end
+
+  defp put_memory(socket, :live_view, bytes) do
+    socket
+    |> assign(:live_view_memory, bytes)
+    |> update(:live_view_peak_memory, &max(&1, bytes))
+  end
+
+  defp process_memory do
+    {:memory, bytes} = Process.info(self(), :memory)
+    bytes
+  end
+
+  defp format_bytes(bytes) when bytes < 1_000, do: "#{bytes} B"
+  defp format_bytes(bytes) when bytes < 1_000_000, do: "#{Float.round(bytes / 1_000, 1)} kB"
+  defp format_bytes(bytes), do: "#{Float.round(bytes / 1_000_000, 1)} MB"
+
+  defp exception_message({exception, _stacktrace}) when is_exception(exception), do: Exception.message(exception)
+  defp exception_message(exception) when is_exception(exception), do: Exception.message(exception)
+  defp exception_message(reason), do: "Streaming failed: #{inspect(reason)}"
 end
 
-PhoenixPlayground.start(plug: DemoRouter, open_browser: true)
+unless System.get_env("MDEX_STREAMING_EXAMPLE_NO_SERVER") == "1" do
+  open_browser? = System.get_env("MDEX_STREAMING_EXAMPLE_NO_BROWSER") != "1"
+  PhoenixPlayground.start(live: MDExStreamingDemo, open_browser: open_browser?)
+end

--- a/guides/plugins.md
+++ b/guides/plugins.md
@@ -48,6 +48,56 @@ MDEx.new(markdown: "# Hello")
 |> MDEx.to_html!()
 ```
 
+## Streaming Plugins
+
+Pass plugins to `MDEx.stream/2` with the same `:plugins` option:
+
+```elixir
+chunks
+|> MDEx.stream(plugins: [{MyPlugin, custom_option: "value"}])
+|> Stream.map(fn {id, document} ->
+  {id, MDEx.to_html!(document)}
+end)
+```
+
+The streaming lifecycle differs from the one-document lifecycle:
+
+1. Stream enumeration starts.
+2. MDEx creates an empty document and calls each plugin's `attach/2` once.
+3. MDEx uses the resulting parser options for every source parse.
+4. MDEx runs the configured pipeline steps on every emitted document.
+5. A repeated id receives a new document built from the latest source. State
+   from the earlier document is not reused.
+
+An emitted document contains one keyed chunk, not the full Markdown response.
+A plugin step must therefore treat the document as independent.
+
+### Plugin author rules
+
+- Use `attach/2` to register options, configure MDEx, and append pipeline steps.
+- Do not read or rewrite `document.buffer` in `attach/2`. The buffer is empty
+  because the source Stream has not been read yet.
+- Make each pipeline step work with one keyed document.
+- Do not rely on `document.private`, assigns, counters, or transformed nodes
+  from an earlier update. Each update starts from the plugin configuration.
+- Expect a pipeline step to run again when the same id is replaced.
+- Parser options set during `attach/2` apply before both normal and partial
+  parsing. Parser options set inside a pipeline step are too late to change the
+  AST that the step receives.
+- Do not assume generated IDs are unique across keyed chunks. Include external
+  context in an ID when response-wide uniqueness is required.
+- Prefer loading CSS and JavaScript in the surrounding page. Assets inserted
+  into the document root may be repeated in several keyed chunks.
+- Keep document-wide transforms on the one-document API. Examples include a
+  table of contents, global numbering, collected footnotes, and source
+  preprocessing.
+
+Plugin attachment is lazy. Enumerating a repeatable Stream again attaches the
+plugins again and creates a new pipeline.
+
+See the [Streaming guide](streaming.html#plugins) for the user-facing behavior
+and notes about existing MDEx plugins.
+
 ## Creating Custom Plugins
 
 A plugin is any module that implements an `attach/2` function. This function receives a document and options, and returns a modified document:

--- a/guides/streaming.md
+++ b/guides/streaming.md
@@ -1,126 +1,332 @@
-# Streaming
+# Streaming Markdown
 
-Markdown from LLM responses arrives a few tokens at a time. Rendering each chunk on its own produces broken HTML like unclosed `<strong>` tags, half-open code fences, and tables missing their closing pipes.
+> #### Unreleased {: .warning}
+>
+> This API is on the development branch. It is not on Hex yet.
 
-Streaming mode lets you feed those chunks into a document as they arrive and get valid output (HTML, etc) at every step. It buffers fragments, temporarily closes any open syntax before rendering, and when the next chunk arrives, replaces the temporary closings with real content.
-
-## How it works
-
-Three functions:
-
-1. `MDEx.new(streaming: true)` - creates a document with a buffer and a fragment parser.
-2. `MDEx.Document.put_markdown/2` - appends a chunk to the buffer. No parsing happens yet.
-3. `MDEx.to_html!/1` (or any `MDEx.to_*`, or `MDEx.Document.run/1`) - flushes the buffer, closes open syntax, parses, renders.
-
-The fragment parser keeps state between renders. Send `**Fol` and it produces `<strong>Fol</strong>`. Send `low**` next and it re-renders as `<strong>Follow</strong>`.
-
-## Basic usage
+Use `MDEx.stream/2` when Markdown arrives in chunks from an LLM, file, or HTTP
+response.
 
 ```elixir
-doc = MDEx.new(streaming: true)
-
-# First chunk -- unclosed bold marker
-doc = MDEx.Document.put_markdown(doc, "**Fol")
-MDEx.to_html!(doc)
-#=> "<p><strong>Fol</strong></p>"
-
-# Second chunk closes it
-doc = MDEx.Document.put_markdown(doc, "low**")
-MDEx.to_html!(doc)
-#=> "<p><strong>Follow</strong></p>"
+chunks
+|> MDEx.stream(options)
+|> Enum.each(&consume/1)
 ```
 
-Code fences, tables, lists, strikethrough, links -- same idea. The parser knows what's open and closes it until the real closing arrives.
-
-## Piping chunks
+The input is any `Enumerable` of binaries. The result is a lazy Elixir
+`Stream`. MDEx parses each update and emits keyed documents:
 
 ```elixir
-MDEx.new(streaming: true)
-|> MDEx.Document.put_markdown("# Hel")
-|> MDEx.Document.put_markdown("lo\n\nSome ")
-|> MDEx.Document.put_markdown("**bold** text")
-|> MDEx.to_html!()
-#=> "<h1>Hello</h1>\n<p>Some <strong>bold</strong> text</p>"
+{id, %MDEx.Document{}}
 ```
 
-## Using `Enum.into/2`
+The caller does not need to manage parser state.
 
-`MDEx.Document` implements `Collectable`, so you can collect string chunks:
+## Output contract
+
+Each document is parsed and ready to render. Render it in the format your
+application needs:
 
 ```elixir
-chunks = ["# Hel", "lo\n\n", "Some **bold** text"]
-
-doc = Enum.into(chunks, MDEx.new(streaming: true))
-MDEx.to_html!(doc)
-#=> "<h1>Hello</h1>\n<p>Some <strong>bold</strong> text</p>"
+chunks
+|> MDEx.stream(extension: [table: true])
+|> Stream.map(fn {id, document} ->
+  {id, MDEx.to_html!(document)}
+end)
+|> Enum.each(&update_output/1)
 ```
 
-Useful when you already have a list of chunks from an HTTP client or message queue.
-
-## LiveView integration
-
-If you're rendering an LLM response in a Phoenix LiveView, keep the document in assigns and append chunks as they arrive:
+An id may appear more than once:
 
 ```elixir
-defmodule MyAppWeb.ChatLive do
-  use Phoenix.LiveView
+{0, first_document}         # insert
+{1, partial_document}       # insert the open tail
+{1, updated_document}       # replace the tail
+{1, final_document}         # replace it with the EOF parse
+```
 
-  def mount(_params, _session, socket) do
-    {:ok, assign(socket,
-      document: MDEx.new(streaming: true),
-      html: ""
-    )}
-  end
+Apply these rules:
 
-  def render(assigns) do
-    ~H"""
-    <div id="chat-output">{Phoenix.HTML.raw(@html)}</div>
-    """
-  end
+1. Insert a chunk when its id is new.
+2. Replace a chunk when its id repeats.
+3. After MDEx emits a higher id, all lower ids are stable.
+4. Only the highest id may change.
+5. Normal Stream completion is EOF. There is no custom EOF chunk.
 
-  # Each chunk arrives as a message from your AI client
-  def handle_info({:chunk, text}, socket) do
-    document =
-      socket.assigns.document
-      |> MDEx.Document.put_markdown(text)
+A chunk may contain more than one Markdown block. This can happen when a link
+reference or another document-wide rule may change several blocks together.
 
-    html = MDEx.to_html!(document)
+MDEx emits a new immutable document for each update. It does not change a
+document that it already emitted.
 
-    {:noreply, assign(socket, document: document, html: html)}
-  end
+If the consumer stops early, MDEx does not parse input it has not read.
 
-  def handle_info(:done, socket) do
-    html = MDEx.to_html!(socket.assigns.document)
-    {:noreply, assign(socket, html: html)}
-  end
+## Lists and generated streams
+
+```elixir
+["# Hel", "lo\n\n", "Some **bold", " text**"]
+|> MDEx.stream()
+|> Stream.each(fn {_id, document} ->
+  IO.write(MDEx.to_html!(document))
+end)
+|> Stream.run()
+```
+
+You can use normal `Stream` functions before and after `MDEx.stream/2`:
+
+```elixir
+chunk_source
+|> MDEx.stream(options)
+|> Stream.map(fn {id, document} ->
+  {id, MDEx.to_json!(document)}
+end)
+|> Stream.filter(&interesting?/1)
+|> Enum.each(&publish/1)
+```
+
+## File streams
+
+`File.stream!/1` works without an adapter:
+
+```elixir
+"README.md"
+|> File.stream!()
+|> MDEx.stream()
+|> Enum.each(fn {id, document} ->
+  cache({id, :html}, MDEx.to_html!(document))
+end)
+```
+
+You can also read fixed-size binary chunks:
+
+```elixir
+"large.md"
+|> File.stream!([], 2048)
+|> MDEx.stream()
+|> Enum.each(&consume/1)
+```
+
+A file or network chunk may split a UTF-8 code point. MDEx holds the incomplete
+bytes until the next chunk. Invalid UTF-8 raises when the Stream reaches those
+bytes. An incomplete code point at EOF also raises.
+
+## Req response streams
+
+Req can return a response body that implements `Enumerable`:
+
+```elixir
+response = Req.get!(url, into: :self, raw: true)
+
+response.body
+|> MDEx.stream(extension: [table: true])
+|> Enum.each(&consume/1)
+```
+
+The body does not need to be joined first. The process that reads the response
+must also own its timeout, body-size limit, and cancellation rules.
+
+## Partial Markdown
+
+MDEx uses its fragment parser for the current chunk. This keeps partial output
+valid while more source is expected:
+
+```elixir
+["**Fol", "low**"]
+|> MDEx.stream()
+|> Enum.each(fn {_id, document} ->
+  IO.inspect(MDEx.to_html!(document))
+end)
+```
+
+The first update renders a closed `<strong>` element. The next update uses the
+same id and replaces it. At EOF, MDEx parses the source without temporary
+closing syntax.
+
+Fragment parsing supports partial emphasis, code spans, code fences, links,
+images, tables, lists, math, HTML, and other enabled syntax.
+
+## `put_markdown/3`
+
+`MDEx.Document.put_markdown/3` is not deprecated. Use it to build one full
+document for an AST pipeline:
+
+```elixir
+document =
+  MDEx.new()
+  |> MDEx.Document.put_markdown("# Release notes\n\n")
+  |> MDEx.Document.put_markdown("Version **1.0**")
+
+MDEx.to_html!(document)
+#=> "<h1>Release notes</h1>\n<p>Version <strong>1.0</strong></p>"
+```
+
+Use `MDEx.stream/2` for an Enumerable of chunks. It uses the same Markdown
+input path and enables fragment parsing only for the current chunk.
+
+`MDEx.new(streaming: true)` is deprecated. It still warns and works for now.
+
+## Phoenix LiveView
+
+The MDEx id can be the id for a
+[`Phoenix.LiveView.stream/4`](https://phoenix-live-view.hexdocs.pm/Phoenix.LiveView.html#stream/4)
+entry.
+
+Configure the id before you create the LiveView stream:
+
+```elixir
+def mount(_params, _session, socket) do
+  {:ok,
+   socket
+   |> stream_configure(:markdown, dom_id: fn {id, _document} ->
+     "markdown-#{id}"
+   end)
+   |> stream(:markdown, [])}
 end
 ```
 
-The document accumulates all chunks. Each `to_html!/1` call re-renders the full content with fragment completion applied.
+Use the exact DOM id that LiveView gives to the template:
 
-## What gets completed
+```heex
+<div id="markdown" class="markdown-body" phx-update="stream">
+  <div
+    :for={{dom_id, {_id, document}} <- @streams.markdown}
+    id={dom_id}
+    class="contents"
+  >
+    {Phoenix.HTML.raw(MDEx.to_html!(document))}
+  </div>
+</div>
+```
 
-The fragment parser temporarily closes open syntax so every render produces valid output. It covers emphasis markers (`*`, `**`, `_`, `__`), code spans and fences, strikethrough (`~~`), highlight (`==`) and insert (`++`) markers, incomplete links and images, tables with missing pipes, partial list items, and math delimiters (`$`, `$$`).
+Use `Phoenix.HTML.raw/1` only after applying the MDEx safety options required by
+your application.
 
-## Options
+### Read the source outside the LiveView callback
 
-Pass any standard MDEx options alongside `streaming: true`:
+`Phoenix.LiveView.stream/4` reads its Enumerable in the LiveView process. Do
+not pass it an LLM, socket, or other long-running source:
 
 ```elixir
-MDEx.new(
-  streaming: true,
-  extension: [strikethrough: true, table: true, tasklist: true],
-  render: [unsafe: true],
-  syntax_highlight: [engine: :lumis, opts: [formatter: {:html_inline, theme: "github_light"}]]
-)
+# This blocks the LiveView callback until the source ends.
+stream(socket, :markdown, MDEx.stream(long_running_chunks))
 ```
 
-The fragment parser knows about extension syntax, so strikethrough and table constructs get completed correctly too.
+Read the MDEx Stream in a task and send each finite chunk to the LiveView:
 
-## Demo
+```elixir
+def start_markdown(socket, chunks) do
+  live_view = self()
 
-There's a full LiveView demo at `examples/streaming.exs` that simulates an AI response arriving chunk by chunk:
+  start_async(socket, :markdown_producer, fn ->
+    chunks
+    |> MDEx.stream(@mdex_options)
+    |> Enum.each(&send(live_view, {:markdown_chunk, &1}))
+  end)
+end
 
-```bash
+def handle_info({:markdown_chunk, chunk}, socket) do
+  {:noreply, stream_insert(socket, :markdown, chunk)}
+end
+
+def handle_async(:markdown_producer, {:ok, :ok}, socket) do
+  {:noreply, socket}
+end
+```
+
+You may also send a finite list and call `stream/4` once per batch:
+
+```elixir
+def handle_info({:markdown_chunks, chunks}, socket) do
+  {:noreply, stream(socket, :markdown, chunks)}
+end
+```
+
+When an id repeats, LiveView updates the same DOM child. A higher id adds a new
+child. LiveView drops streamed data from socket state after each render, so the
+source and MDEx parser state must stay in the producer.
+
+`stream_async/4` does not forward chunks while its task runs. It waits for the
+task result and then passes that result to `stream/4`.
+
+### Start a new response
+
+MDEx ids start at `0` for each Stream run. Reset the LiveView stream when the UI
+shows one active response:
+
+```elixir
+socket = stream(socket, :markdown, [], reset: true)
+```
+
+For several active responses, include a response id in each DOM id. An MDEx id
+is unique only within one Stream run.
+
+## Runnable Phoenix example
+
+[`examples/streaming.exs`](https://github.com/leandrocp/mdex/blob/main/examples/streaming.exs)
+runs this path:
+
+```text
+Req response body
+  -> MDEx.stream/2
+  -> one {id, document} chunk per message
+  -> Phoenix.LiveView.stream_insert/4
+  -> phx-update="stream"
+```
+
+Run it from the repository:
+
+```shell
 elixir examples/streaming.exs
 ```
+
+The URL defaults to the raw MDEx README on GitHub. The example splits large
+network reads into 64-byte chunks so updates stay visible. The controls include
+a delay of up to 1000 ms and optional auto-scroll.
+
+Lumis highlights partial code fences. The page also shows source counts, MDEx
+updates, DOM chunks, and current and peak memory for the producer and LiveView
+processes.
+
+## Client tests
+
+The API has local test branches in three clients:
+
+- Loopyard reads each backend Stream once, sends text chunks through MDEx, and
+  shares keyed documents with its LiveViews.
+- phoenix_streamdown removes its Markdown repair and block split code. MDEx
+  parses the source; phoenix_streamdown keeps components, styles, and optional
+  animation.
+- Ash AI sends its lazy tool-loop output through MDEx, then sends keyed
+  documents through PubSub to LiveView or LiveComponent code.
+
+In each client, MDEx owns Markdown parsing, partial syntax, stable ids, and EOF.
+The client owns transport, cancellation, pacing, and response ids.
+
+## Push-only sources
+
+If a source only sends process messages, adapt it at the process boundary with
+`Stream.resource/3`. The adapter must define subscribe, EOF, error,
+cancellation, and cleanup behavior. MDEx does not add a separate
+`new/push/finish` API for this case.
+
+## Options and plugins
+
+Pass normal MDEx options as the second argument:
+
+```elixir
+chunks
+|> MDEx.stream(
+  extension: [strikethrough: true, table: true, tasklist: true],
+  render: [unsafe: false],
+  syntax_highlight: [
+    engine: :lumis,
+    opts: [formatter: {:html_inline, theme: "github_light"}]
+  ]
+)
+|> Enum.each(&consume/1)
+```
+
+Plugins that read or change the whole document may not match a render made from
+separate keyed documents. Their support is not defined yet. See
+[`STREAMING_API.md`](https://github.com/leandrocp/mdex/blob/main/STREAMING_API.md)
+for the API contract and open release work.

--- a/guides/streaming.md
+++ b/guides/streaming.md
@@ -61,6 +61,92 @@ document that it already emitted.
 
 If the consumer stops early, MDEx does not parse input it has not read.
 
+## Change the AST before rendering
+
+Each emitted `%MDEx.Document{}` contains a parsed AST. You can change its nodes
+before rendering it. Do not call `MDEx.parse_document!/2` again.
+
+This example sends external links through a redirect service:
+
+```elixir
+def rewrite_links(document) do
+  MDEx.Document.update_nodes(document, MDEx.Link, fn link ->
+    url = "https://example.test/redirect?to=" <> URI.encode_www_form(link.url)
+    %{link | url: url}
+  end)
+end
+
+chunks
+|> MDEx.stream()
+|> Stream.map(fn {id, document} ->
+  document = rewrite_links(document)
+  {id, MDEx.to_html!(document)}
+end)
+|> Enum.each(&update_output/1)
+```
+
+Apply the transform to every emitted chunk, including repeated ids. A partial
+link may become a complete link in a later update with the same id. A reference
+link may also become available after its definition arrives.
+
+### Whole-document limit
+
+The document in `{id, document}` is one keyed chunk, not the full Markdown
+response. A transform that only needs nodes in that chunk, such as rewriting a
+link or adding attributes, works directly.
+
+A transform that needs all content may produce a different result. Examples
+include a table of contents, heading ids that must be unique across the whole
+response, and numbering shared by several chunks. For those transforms, either
+wait for the full source or keep state outside MDEx and account for repeated
+tail ids.
+
+## Plugins
+
+Pass plugins through the normal `:plugins` option:
+
+```elixir
+chunks
+|> MDEx.stream(plugins: [MDExGFM])
+|> Stream.map(fn {id, document} ->
+  {id, MDEx.to_html!(document)}
+end)
+```
+
+MDEx attaches each plugin once when Stream enumeration starts. Extension,
+parse, and render options set by `attach/2` apply to every parse. Plugin
+pipeline steps then run on every emitted document, including updates with a
+repeated id.
+
+Each run starts from the prepared plugin configuration. Changes that a plugin
+makes to one emitted document are not carried into the next update.
+
+The keyed document limit still applies:
+
+- An AST transform that only needs the current chunk works directly.
+- Assets injected at the document root may appear in more than one keyed
+  chunk.
+- Sequence numbers and generated IDs restart for each keyed chunk. They are not
+  unique across the full response.
+- A plugin cannot build a table of contents or other full-response result
+  without external state.
+- `attach/2` runs before MDEx reads source chunks, so it receives a document
+  with an empty Markdown buffer. A plugin that preprocesses the raw Markdown
+  buffer is not compatible with `MDEx.stream/2`; use the one-document API.
+
+For the plugins listed in the MDEx README, this means:
+
+- `mdex_gfm` parser options apply normally.
+- `mdex_custom_heading_id` processes headings within each keyed chunk.
+- `mdex_mermaid`, `mdex_katex`, `mdex_video_embed`, and `mdex_mermex` process
+  each keyed chunk separately. Configure document-wide assets and globally
+  unique IDs outside the Markdown stream when needed.
+- `mdex_multiline_cells` preprocesses the Markdown buffer and should be used
+  after the complete Markdown response is available.
+
+See the [Plugins guide](plugins.html#streaming-plugins) for the plugin-author
+contract.
+
 ## Lists and generated streams
 
 ```elixir

--- a/lib/mdex.ex
+++ b/lib/mdex.ex
@@ -1376,6 +1376,28 @@ defmodule MDEx do
   A file or network read may split a UTF-8 code point. MDEx holds the incomplete
   bytes until the next chunk.
 
+  Each document contains a parsed AST. It can be changed before rendering:
+
+      markdown_chunks
+      |> MDEx.stream()
+      |> Stream.map(fn {id, document} ->
+        document =
+          MDEx.Document.update_nodes(document, MDEx.Link, fn link ->
+            %{link | url: rewrite_url(link.url)}
+          end)
+
+        {id, MDEx.to_html!(document)}
+      end)
+
+  The transform sees one keyed document, not the full Markdown response. A
+  transform that needs all content must wait for the full source or keep its
+  own state across chunks and repeated ids.
+
+  Plugins are attached once when the Stream starts. Parser options configured
+  by a plugin apply to every parse. The plugin pipeline runs on every emitted
+  document, including replacements with the same id. Plugins must not expect an
+  emitted document or its buffer to contain the full Markdown response.
+
   ## Examples
 
       iex> ["# Hel", "lo\\n\\nNow **wri", "ting**"]
@@ -1411,10 +1433,17 @@ defmodule MDEx do
     chunks
     |> Stream.transform(
       fn ->
+        document =
+          options
+          |> Keyword.drop([:document, :markdown, :streaming])
+          |> new()
+
         %{
-          options: Keyword.drop(options, [:document, :markdown, :streaming]),
+          document: document,
+          rust_options: Document.rust_options!(document.options),
           source: "",
           utf8_suffix: "",
+          tail_nodes: nil,
           tail_id: nil,
           next_id: 0
         }
@@ -1451,18 +1480,34 @@ defmodule MDEx do
 
   defp finish_stream(state) do
     id = state.tail_id || state.next_id
-    {[{id, stream_document(state.source, state.options, false)}], state}
+    document = stream_final_document(state.source, state.tail_nodes, state.document)
+    {[{id, document}], state}
   end
 
   defp emit_stream_source(source, state) do
-    {stable_source, mutable_source} = partition_stream_source(source, state.options)
+    partition = partition_stream_source(source, state.rust_options)
 
-    case stable_source do
+    case partition.stable_source do
       "" ->
         id = state.tail_id || state.next_id
         next_id = if state.tail_id, do: state.next_id, else: state.next_id + 1
-        chunks = if mutable_source == "", do: [], else: [{id, stream_document(mutable_source, state.options, true)}]
-        {chunks, %{state | source: mutable_source, tail_id: id, next_id: next_id}}
+
+        chunks =
+          if partition.tail_source == "" do
+            []
+          else
+            [{id, stream_fragment_document(partition.tail_source, state.document)}]
+          end
+
+        new_state = %{
+          state
+          | source: partition.tail_source,
+            tail_nodes: partition.tail_nodes,
+            tail_id: id,
+            next_id: next_id
+        }
+
+        {chunks, new_state}
 
       _ ->
         stable_id = state.tail_id || state.next_id
@@ -1470,47 +1515,78 @@ defmodule MDEx do
         tail_id = next_id
 
         chunks = [
-          {stable_id, stream_document(stable_source, state.options, false)},
-          {tail_id, stream_document(mutable_source, state.options, true)}
+          {stable_id, stream_parsed_document(partition.stable_nodes, state.document)},
+          {tail_id, stream_fragment_document(partition.tail_source, state.document)}
         ]
 
-        {chunks, %{state | source: mutable_source, tail_id: tail_id, next_id: next_id + 1}}
+        new_state = %{
+          state
+          | source: partition.tail_source,
+            tail_nodes: partition.tail_nodes,
+            tail_id: tail_id,
+            next_id: next_id + 1
+        }
+
+        {chunks, new_state}
     end
   end
 
-  defp stream_document(source, options, streaming?) do
-    document = new(options)
-    document = if streaming?, do: Document.put_private(document, :fragment_completion, true), else: document
+  defp stream_fragment_document(source, document) do
+    document
+    |> Document.put_private(:fragment_completion, true)
+    |> Document.put_markdown(source)
+    |> Document.run()
+  end
 
+  defp stream_source_document(source, document) do
     document
     |> Document.put_markdown(source)
     |> Document.run()
   end
 
-  defp partition_stream_source("", _options), do: {"", ""}
+  defp stream_parsed_document(nodes, document) do
+    document
+    |> Map.put(:nodes, nodes)
+    |> Document.run()
+  end
 
-  defp partition_stream_source(source, options) do
-    boundary_options = Keyword.drop(options, [:assigns, :plugins])
-    rust_options = Document.rust_options!(boundary_options)
+  defp stream_final_document(source, nil, document), do: stream_source_document(source, document)
+  defp stream_final_document(_source, nodes, document), do: stream_parsed_document(nodes, document)
 
+  defp partition_stream_source("", _rust_options) do
+    %{stable_source: "", stable_nodes: [], tail_source: "", tail_nodes: []}
+  end
+
+  defp partition_stream_source(source, rust_options) do
     case Comrak.parse_document_with_metadata(source, rust_options) do
       {%{nodes: native_nodes}, metadata} ->
         nodes = ComrakConverter.to_mdex(native_nodes)
         blocks = stream_source_blocks(source, nodes, metadata)
-        {stable, mutable} = Enum.split_while(blocks, &elem(&1, 1))
-        {Enum.map_join(stable, &elem(&1, 0)), Enum.map_join(mutable, &elem(&1, 0))}
+        {stable, tail} = Enum.split_while(blocks, &elem(&1, 1))
+        tail_line_offset = stream_tail_line_offset(tail)
+
+        %{
+          stable_source: Enum.map_join(stable, &elem(&1, 0)),
+          stable_nodes: Enum.flat_map(stable, &elem(&1, 2)),
+          tail_source: Enum.map_join(tail, &elem(&1, 0)),
+          tail_nodes:
+            tail
+            |> Enum.flat_map(&elem(&1, 2))
+            |> rebase_stream_nodes(tail_line_offset)
+        }
 
       _ ->
-        {"", source}
+        %{stable_source: "", stable_nodes: [], tail_source: source, tail_nodes: nil}
     end
   end
 
-  defp stream_source_blocks(source, [], _metadata), do: [{source, false}]
+  defp stream_source_blocks(source, [], _metadata), do: [{source, false, [], 1}]
 
   defp stream_source_blocks(source, nodes, metadata) do
     starts = stream_line_starts(source)
 
-    positions = stream_node_positions(nodes)
+    groups = stream_node_groups(nodes)
+    positions = Enum.map(groups, fn {start_line, end_line, _nodes} -> {start_line, end_line} end)
 
     offsets =
       positions
@@ -1528,27 +1604,31 @@ defmodule MDEx do
     [0 | offsets]
     |> Enum.zip(offsets ++ [byte_size(source)])
     |> Enum.zip(boundaries)
-    |> Enum.map(fn {{from, to}, stable?} ->
-      {binary_part(source, from, to - from), stable?}
+    |> Enum.zip(groups)
+    |> Enum.map(fn {{{from, to}, stable?}, {start_line, _end_line, nodes}} ->
+      {binary_part(source, from, to - from), stable?, nodes, start_line}
     end)
     |> hold_stream_reference_block(positions, metadata)
   end
 
-  defp stream_node_positions(nodes) do
+  defp stream_node_groups(nodes) do
     nodes
-    |> Enum.reduce([], fn node, positions ->
+    |> Enum.reduce([], fn node, groups ->
       {start_line, _start_column} = node.sourcepos.start
       {end_line, _end_column} = node.sourcepos.end
 
-      case positions do
-        [{^start_line, previous_end_line} | rest] ->
-          [{start_line, max(end_line, previous_end_line)} | rest]
+      case groups do
+        [{^start_line, previous_end_line, grouped_nodes} | rest] ->
+          [{start_line, max(end_line, previous_end_line), [node | grouped_nodes]} | rest]
 
         _other ->
-          [{start_line, end_line} | positions]
+          [{start_line, end_line, [node]} | groups]
       end
     end)
     |> Enum.reverse()
+    |> Enum.map(fn {start_line, end_line, grouped_nodes} ->
+      {start_line, end_line, Enum.reverse(grouped_nodes)}
+    end)
   end
 
   defp hold_stream_reference_block(blocks, _positions, %{reference_link_block_start: nil}),
@@ -1563,9 +1643,42 @@ defmodule MDEx do
     blocks
     |> Enum.with_index()
     |> Enum.map(fn
-      {{source, _stable?}, index} when index >= first_reference -> {source, false}
-      {block, _index} -> block
+      {{source, _stable?, nodes, start_line}, index} when index >= first_reference ->
+        {source, false, nodes, start_line}
+
+      {block, _index} ->
+        block
     end)
+  end
+
+  defp stream_tail_line_offset([]), do: 0
+  defp stream_tail_line_offset([{_source, _stable?, _nodes, start_line} | _rest]), do: start_line - 1
+
+  defp rebase_stream_nodes(nodes, 0), do: nodes
+
+  defp rebase_stream_nodes(nodes, line_offset) do
+    Enum.map(nodes, &rebase_stream_node(&1, line_offset))
+  end
+
+  defp rebase_stream_node(node, line_offset) do
+    node = Map.update!(node, :sourcepos, &rebase_stream_sourcepos(&1, line_offset))
+
+    if Map.has_key?(node, :nodes) do
+      Map.update!(node, :nodes, &rebase_stream_nodes(&1, line_offset))
+    else
+      node
+    end
+  end
+
+  defp rebase_stream_sourcepos(sourcepos, line_offset) do
+    {start_line, start_column} = sourcepos.start
+    {end_line, end_column} = sourcepos.end
+
+    %{
+      sourcepos
+      | start: {max(start_line - line_offset, 1), start_column},
+        end: {max(end_line - line_offset, 1), end_column}
+    }
   end
 
   defp stream_line_starts(source) do

--- a/lib/mdex.ex
+++ b/lib/mdex.ex
@@ -1270,34 +1270,36 @@ defmodule MDEx do
   @type plugins :: [module() | {module(), keyword()} | (MDEx.Document.t() -> MDEx.Document.t())]
 
   @doc """
-  Builds a new `MDEx.Document` instance.
+  Creates an `MDEx.Document`.
 
-  `MDEx.Document` is the core data structure used across MDEx. It holds the full CommonMark AST and
-  exposes rich `Access`, `Enumerable`, and pipeline APIs so you can traverse, manipulate, and enrich
-  Markdown before turning it into HTML/JSON/XML/Markdown/Delta.
+  A document stores the CommonMark AST, options, and pipeline steps. Use it to
+  read or change nodes before rendering.
 
-  * Pass `:markdown` to include Markdown into the buffer or call `MDEx.Document.put_markdown/2` to add more later.
-  * Pass any built-in options (`:extension`, `:parse`, `:render`, `:syntax_highlight`, `:sanitize`) to
-    shape how the document will be parsed and rendered.
-  * Chain pipeline helpers such as `MDEx.Document.append_steps/2`, `MDEx.Document.update_nodes/3`, or your own plugin
-    modules to programmatically modify the AST.
-  * Set `streaming: true` to buffer complete or incomplete Markdown fragments.
+  - Pass `:markdown` to add source when the document is created.
+  - Call `MDEx.Document.put_markdown/3` to add more source later.
+  - Pass MDEx options to control parsing and rendering.
+  - Add pipeline steps or plugins to change the AST.
+  - Use `MDEx.stream/2` instead when the source is an Enumerable of chunks.
 
-  Once you finish manipulating the document, call one of the `MDEx.to_*` functions to output the final result to a format
-  or `MDEx.Document.run/1` to finalize the document and get the updated AST.
+  Call an `MDEx.to_*` function to render the document. Call
+  `MDEx.Document.run/1` when you need the parsed AST.
 
   ## Options
 
-    - `:markdown` (`t:String.t/0`)  Raw Markdown to parse into the document. Defaults to `""`
-    - `:plugins` - (`t:plugins/0`) Attach [plugins](`m:MDEx.Document#module-pipeline-and-plugins`) to the document pipeline. Defaults to `[]`
-    - `:extension` (`t:MDEx.Document.extension_options/0`) Enable extensions. Defaults to `MDEx.Document.default_extension_options/0`
-    - `:parse` - (`t:MDEx.Document.parse_options/0`) Modify parsing behavior. Defaults to `MDEx.Document.default_parse_options/0`
-    - `:render` - (`t:MDEx.Document.render_options/0`) Modify rendering behavior. Defaults to `MDEx.Document.default_render_options/0`
-    - `:syntax_highlight` - (`t:MDEx.Document.syntax_highlight_options/0` | `nil`) Modify syntax highlighting behavior or `nil` to disable. Defaults to `MDEx.Document.default_syntax_highlight_options/0`
-    - `:sanitize` - (`t:sanitize_options/0` | `nil`) Modify sanitization behavior  or `nil` to disable sanitization. Use `MDEx.Document.default_sanitize_options/0` to enable a default set of sanitization options. Defaults to `nil`.
-    - `:assigns` - (`t:map/0`) A map of assigns for use in pipelines, plugins, and HEEx rendering. Can also be set with `MDEx.Document.assign/2`. Defaults to `%{}`.
+    - `:markdown` (`t:String.t/0`) - Markdown source. Defaults to `""`.
+    - `:plugins` (`t:plugins/0`) - Plugins for the document pipeline. Defaults to `[]`.
+    - `:extension` (`t:MDEx.Document.extension_options/0`) - Markdown extensions.
+    - `:parse` (`t:MDEx.Document.parse_options/0`) - Parser options.
+    - `:render` (`t:MDEx.Document.render_options/0`) - Render options.
+    - `:syntax_highlight` (`t:MDEx.Document.syntax_highlight_options/0` | `nil`) - Syntax highlight options, or `nil` to turn it off.
+    - `:sanitize` (`t:sanitize_options/0` | `nil`) - HTML cleaning options, or `nil` to turn it off. Defaults to `nil`.
+    - `:assigns` (`t:map/0`) - Values for pipelines, plugins, and HEEx. Defaults to `%{}`.
 
-  Note that `:sanitize` and `:unsafe` are disabled by default. See [Safety](https://hexdocs.pm/mdex/safety.html) for more info.
+  The `:streaming` option is deprecated. Pass an Enumerable of Markdown chunks
+  to `MDEx.stream/2`.
+
+  `:sanitize` and `:unsafe` are off by default. See the
+  [Safety guide](https://hexdocs.pm/mdex/safety.html).
 
   ## Examples
 
@@ -1315,7 +1317,7 @@ defmodule MDEx do
       ...> |> MDEx.to_html!(render: [unsafe: true])
       "<h1>Intro</h1>\\n<section>Injected</section>"
 
-  Using `MDEx.Document.run/1` to process buffered markdown and get the AST:
+  Parse buffered Markdown and return the AST with `MDEx.Document.run/1`:
 
       iex> doc = MDEx.new(markdown: "# First\\n")
       ...> |> MDEx.Document.put_markdown("# Second")
@@ -1325,13 +1327,6 @@ defmodule MDEx do
         %MDEx.Heading{nodes: [%MDEx.Text{literal: "First", sourcepos: %MDEx.Sourcepos{start: {1, 3}, end: {1, 7}}}], level: 1, setext: false, closed: false, sourcepos: %MDEx.Sourcepos{start: {1, 1}, end: {1, 7}}},
         %MDEx.Heading{nodes: [%MDEx.Text{literal: "Second", sourcepos: %MDEx.Sourcepos{start: {2, 3}, end: {2, 8}}}], level: 1, setext: false, closed: false, sourcepos: %MDEx.Sourcepos{start: {2, 1}, end: {2, 8}}}
       ]
-
-  Enabling streaming to render partial input as it arrives:
-
-      iex> MDEx.new(streaming: true, extension: [strikethrough: true])
-      ...> |> MDEx.Document.put_markdown("~~deprec")
-      ...> |> MDEx.to_html!()
-      "<p><del>deprec</del></p>"
 
   Attach [plugins](plugins.html) three different ways:
 
@@ -1350,6 +1345,10 @@ defmodule MDEx do
   """
   @spec new(keyword()) :: Document.t()
   def new(options \\ []) do
+    if Keyword.has_key?(options, :streaming) do
+      IO.warn("the :streaming option is deprecated; pass an Enumerable of Markdown chunks to MDEx.stream/2")
+    end
+
     # TODO: remove :document in v1.0
     {document, options} = Keyword.pop(options, :document, nil)
     {markdown, options} = Keyword.pop(options, :markdown, nil)
@@ -1362,6 +1361,236 @@ defmodule MDEx do
     @document
     |> Document.put_markdown(markdown)
     |> Document.put_options(options)
+  end
+
+  @doc """
+  Returns a lazy Stream of parsed Markdown chunks.
+
+  The input must be an Enumerable of binaries. The output is a native Elixir
+  `Stream` of `{id, %MDEx.Document{}}` pairs.
+
+  Insert a chunk when its id is new. Replace it when the id repeats. After a
+  higher id appears, all lower ids are stable and will not appear again. EOF
+  emits the last chunk with a normal parse, then ends the Stream.
+
+  A file or network read may split a UTF-8 code point. MDEx holds the incomplete
+  bytes until the next chunk.
+
+  ## Examples
+
+      iex> ["# Hel", "lo\\n\\nNow **wri", "ting**"]
+      ...> |> MDEx.stream()
+      ...> |> Enum.map(fn {id, document} -> {id, MDEx.to_html!(document)} end)
+      [
+        {0, "<h1>Hel</h1>"},
+        {0, "<h1>Hello</h1>"},
+        {1, "<p>Now <strong>wri</strong></p>"},
+        {1, "<p>Now <strong>writing</strong></p>"},
+        {1, "<p>Now <strong>writing</strong></p>"}
+      ]
+
+  `File.stream!/1` and other Enumerables work without an adapter:
+
+      "README.md"
+      |> File.stream!([], 2048)
+      |> MDEx.stream(extension: [table: true])
+      |> Enum.each(fn {id, document} ->
+        cache({id, :html}, MDEx.to_html!(document))
+      end)
+
+  See the [Streaming guide](streaming.html) for the id rules, Req, and Phoenix
+  LiveView.
+
+  > #### Experimental {: .warning}
+  >
+  > This function may change before its first stable release.
+
+  """
+  @spec stream(Enumerable.t(), Document.options()) :: Enumerable.t()
+  def stream(chunks, options \\ []) when is_list(options) do
+    chunks
+    |> Stream.transform(
+      fn ->
+        %{
+          options: Keyword.drop(options, [:document, :markdown, :streaming]),
+          source: "",
+          utf8_suffix: "",
+          tail_id: nil,
+          next_id: 0
+        }
+      end,
+      &stream_chunk/2,
+      &finish_stream/1,
+      fn _state -> :ok end
+    )
+    # Stream.transform/5 provides lifecycle callbacks through an Enumerable
+    # function. This no-op native transform keeps the public value a %Stream{}.
+    |> Stream.map(& &1)
+  end
+
+  defp stream_chunk(chunk, state) when is_binary(chunk) do
+    {valid, utf8_suffix} = split_incomplete_utf8(state.utf8_suffix <> chunk)
+    state = %{state | utf8_suffix: utf8_suffix}
+
+    case valid do
+      "" -> {[], state}
+      _ -> emit_stream_source(state.source <> valid, state)
+    end
+  end
+
+  defp stream_chunk(chunk, _state) do
+    raise ArgumentError, "MDEx.stream/2 expected a binary chunk, got: #{inspect(chunk)}"
+  end
+
+  defp finish_stream(%{utf8_suffix: suffix}) when suffix != "" do
+    raise ArgumentError,
+          "MDEx.stream/2 reached end-of-input with incomplete UTF-8: #{inspect(suffix)}"
+  end
+
+  defp finish_stream(%{source: ""} = state), do: {[], state}
+
+  defp finish_stream(state) do
+    id = state.tail_id || state.next_id
+    {[{id, stream_document(state.source, state.options, false)}], state}
+  end
+
+  defp emit_stream_source(source, state) do
+    {stable_source, mutable_source} = partition_stream_source(source, state.options)
+
+    case stable_source do
+      "" ->
+        id = state.tail_id || state.next_id
+        next_id = if state.tail_id, do: state.next_id, else: state.next_id + 1
+        chunks = if mutable_source == "", do: [], else: [{id, stream_document(mutable_source, state.options, true)}]
+        {chunks, %{state | source: mutable_source, tail_id: id, next_id: next_id}}
+
+      _ ->
+        stable_id = state.tail_id || state.next_id
+        next_id = if state.tail_id, do: state.next_id, else: state.next_id + 1
+        tail_id = next_id
+
+        chunks = [
+          {stable_id, stream_document(stable_source, state.options, false)},
+          {tail_id, stream_document(mutable_source, state.options, true)}
+        ]
+
+        {chunks, %{state | source: mutable_source, tail_id: tail_id, next_id: next_id + 1}}
+    end
+  end
+
+  defp stream_document(source, options, streaming?) do
+    document = new(options)
+    document = if streaming?, do: Document.put_private(document, :fragment_completion, true), else: document
+
+    document
+    |> Document.put_markdown(source)
+    |> Document.run()
+  end
+
+  defp partition_stream_source("", _options), do: {"", ""}
+
+  defp partition_stream_source(source, options) do
+    boundary_options = Keyword.drop(options, [:assigns, :plugins])
+    rust_options = Document.rust_options!(boundary_options)
+
+    case Comrak.parse_document_with_metadata(source, rust_options) do
+      {%{nodes: native_nodes}, metadata} ->
+        nodes = ComrakConverter.to_mdex(native_nodes)
+        blocks = stream_source_blocks(source, nodes, metadata)
+        {stable, mutable} = Enum.split_while(blocks, &elem(&1, 1))
+        {Enum.map_join(stable, &elem(&1, 0)), Enum.map_join(mutable, &elem(&1, 0))}
+
+      _ ->
+        {"", source}
+    end
+  end
+
+  defp stream_source_blocks(source, [], _metadata), do: [{source, false}]
+
+  defp stream_source_blocks(source, nodes, metadata) do
+    starts = stream_line_starts(source)
+
+    positions = stream_node_positions(nodes)
+
+    offsets =
+      positions
+      |> tl()
+      |> Enum.map(fn {start_line, _end_line} -> stream_byte_at(starts, start_line) end)
+
+    boundaries =
+      positions
+      |> Enum.zip(tl(positions) ++ [nil])
+      |> Enum.map(fn
+        {{_start_line, end_line}, {next_start_line, _next_end_line}} -> next_start_line > end_line + 1
+        {_position, nil} -> false
+      end)
+
+    [0 | offsets]
+    |> Enum.zip(offsets ++ [byte_size(source)])
+    |> Enum.zip(boundaries)
+    |> Enum.map(fn {{from, to}, stable?} ->
+      {binary_part(source, from, to - from), stable?}
+    end)
+    |> hold_stream_reference_block(positions, metadata)
+  end
+
+  defp stream_node_positions(nodes) do
+    nodes
+    |> Enum.reduce([], fn node, positions ->
+      {start_line, _start_column} = node.sourcepos.start
+      {end_line, _end_column} = node.sourcepos.end
+
+      case positions do
+        [{^start_line, previous_end_line} | rest] ->
+          [{start_line, max(end_line, previous_end_line)} | rest]
+
+        _other ->
+          [{start_line, end_line} | positions]
+      end
+    end)
+    |> Enum.reverse()
+  end
+
+  defp hold_stream_reference_block(blocks, _positions, %{reference_link_block_start: nil}),
+    do: blocks
+
+  defp hold_stream_reference_block(blocks, positions, %{reference_link_block_start: start_line}) do
+    first_reference =
+      Enum.find_index(positions, fn {block_start_line, _end_line} ->
+        block_start_line >= start_line
+      end) || 0
+
+    blocks
+    |> Enum.with_index()
+    |> Enum.map(fn
+      {{source, _stable?}, index} when index >= first_reference -> {source, false}
+      {block, _index} -> block
+    end)
+  end
+
+  defp stream_line_starts(source) do
+    source
+    |> :binary.matches("\n")
+    |> Enum.map(fn {offset, length} -> offset + length end)
+    |> then(&[0 | &1])
+    |> List.to_tuple()
+  end
+
+  defp stream_byte_at(starts, line) do
+    elem(starts, min(max(line - 1, 0), tuple_size(starts) - 1))
+  end
+
+  defp split_incomplete_utf8(binary) do
+    case :unicode.characters_to_binary(binary, :utf8, :utf8) do
+      valid when is_binary(valid) ->
+        {valid, ""}
+
+      {:incomplete, valid, suffix} ->
+        {valid, suffix}
+
+      {:error, _valid, invalid} ->
+        raise ArgumentError, "MDEx.stream/2 received invalid UTF-8: #{inspect(invalid)}"
+    end
   end
 
   @doc """

--- a/lib/mdex/document.ex
+++ b/lib/mdex/document.ex
@@ -104,16 +104,11 @@ defmodule MDEx.Document do
 
   ## Streaming
 
-  Pass `streaming: true` to buffer Markdown fragments and get valid output at every render,
-  even when chunks arrive with unclosed syntax. Useful for rendering LLM responses as they stream in.
+  Use `MDEx.stream/2` for an Enumerable of Markdown chunks. Use
+  `put_markdown/3` to build one document in steps.
 
-      iex> doc = MDEx.new(streaming: true) |> MDEx.Document.put_markdown("**Fol")
-      iex> MDEx.to_html!(doc)
-      "<p><strong>Fol</strong></p>"
-      iex> doc |> MDEx.Document.put_markdown("low**") |> MDEx.to_html!()
-      "<p><strong>Follow</strong></p>"
-
-  See the [Streaming guide](streaming.html) for details on LiveView integration, fragment completion, and a full demo.
+  See the [Streaming guide](streaming.html) for partial Markdown, Req, and
+  Phoenix LiveView.
 
   ## Protocols
 
@@ -1327,11 +1322,6 @@ defmodule MDEx.Document do
       See the [Safety](#module-safety) section for more info.
       """
     ],
-    streaming: [
-      type: :boolean,
-      default: false,
-      doc: "Enables streaming. See the [Streaming guide](streaming.html) for details."
-    ],
     assigns: [
       type: :map,
       default: %{},
@@ -1642,7 +1632,9 @@ defmodule MDEx.Document do
         put_sanitize_options(acc, options)
 
       {:streaming, value}, acc ->
-        %{acc | options: Keyword.put(acc.options || [], :streaming, value)}
+        acc
+        |> Map.update!(:options, &Keyword.put(&1 || [], :streaming, value))
+        |> Document.put_private(:fragment_completion, value)
 
       {:assigns, value}, acc ->
         %{acc | options: Keyword.put(acc.options || [], :assigns, value)}
@@ -2152,7 +2144,7 @@ defmodule MDEx.Document do
   1. Processes buffered markdown: If there are any markdown chunks in the buffer (added via `put_markdown/3` for example),
      they are parsed and added to the document. If the document already has nodes, they are combined with the buffer.
 
-  2. Completes any buffered fragments: If streaming is enabled, it completes any buffered fragments to ensure valid Markdown.
+  2. Closes partial syntax when called by `MDEx.stream/2`.
 
   3. Executes pipeline steps: All registered steps (added via `append_steps/2` or `prepend_steps/2`) are
      executed in order. Steps can transform the document or halt the pipeline.
@@ -2184,15 +2176,6 @@ defmodule MDEx.Document do
       ...>   |> MDEx.Document.run()
       iex> document.nodes
       [%MDEx.Heading{nodes: [%MDEx.Text{literal: "Intro"}], level: 1, setext: false}]
-
-  Streaming:
-
-      iex> document =
-      ...>   MDEx.new(streaming: true, markdown: "```elixir\\n")
-      ...>   |> MDEx.Document.put_markdown("IO.inspect(:mdex)")
-      ...>   |> MDEx.Document.run()
-      iex> document.nodes
-      [%MDEx.CodeBlock{nodes: [], fenced: true, fence_char: "`", fence_length: 3, fence_offset: 0, info: "elixir", literal: "IO.inspect(:mdex)\\n", closed: true, sourcepos: %MDEx.Sourcepos{start: {1, 1}, end: {3, 3}}}]
 
   """
   @spec run(t()) :: t()
@@ -2261,7 +2244,7 @@ defmodule MDEx.Document do
 
   defp flush_buffer(document, buffer) do
     {buffer, document} =
-      if Document.get_option(document, :streaming) do
+      if Document.get_private(document, :fragment_completion, false) do
         state = Document.get_private(document, :fragment_state)
         {completed, new_state} = MDEx.FragmentParser.complete_with_state(buffer, state)
         {completed, Document.put_private(document, :fragment_state, new_state)}
@@ -2377,7 +2360,7 @@ defmodule MDEx.Document do
   end
 
   @doc """
-  Adds `markdown` chunks into the `document` buffer.
+  Adds Markdown to the document buffer.
 
   ## Examples
 
@@ -2401,7 +2384,7 @@ defmodule MDEx.Document do
         %MDEx.Heading{nodes: [%MDEx.Text{literal: "Last", sourcepos: %MDEx.Sourcepos{start: {2, 3}, end: {2, 6}}}], level: 1, setext: false, closed: false, sourcepos: %MDEx.Sourcepos{start: {2, 1}, end: {2, 6}}}
       ]
 
-      iex> document = MDEx.new(streaming: true) |> MDEx.Document.put_markdown("`let x =")
+      iex> document = MDEx.new() |> MDEx.Document.put_markdown("`let x =`")
       iex> MDEx.to_html!(document)
       "<p><code>let x =</code></p>"
 
@@ -2738,8 +2721,8 @@ defmodule MDEx.Document do
   if Code.ensure_loaded?(Lumis) do
     defp lumis_syntax_highlight_options(options) do
       options
-      |> Lumis.validate_options!()
-      |> Lumis.rust_options!()
+      |> then(&apply(Lumis, :validate_options!, [&1]))
+      |> then(&apply(Lumis, :rust_options!, [&1]))
     end
   else
     defp lumis_syntax_highlight_options(_options) do

--- a/mix.exs
+++ b/mix.exs
@@ -187,7 +187,7 @@ defmodule MDEx.MixProject do
     if path = System.get_env("MDEX_NATIVE_PATH") do
       {:mdex_native, path: path}
     else
-      {:mdex_native, ">= 0.2.6"}
+      {:mdex_native, ">= 0.2.9"}
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -187,7 +187,7 @@ defmodule MDEx.MixProject do
     if path = System.get_env("MDEX_NATIVE_PATH") do
       {:mdex_native, path: path}
     else
-      {:mdex_native, ">= 0.2.9"}
+      {:mdex_native, ">= 0.2.10"}
     end
   end
 

--- a/test/mdex/stream_test.exs
+++ b/test/mdex/stream_test.exs
@@ -1,5 +1,5 @@
 defmodule MDEx.StreamTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   import ExUnit.CaptureIO
 
@@ -226,6 +226,115 @@ defmodule MDEx.StreamTest do
     assert MDEx.to_html!(final_next) == "<p>Next</p>"
   end
 
+  test "reuses the metadata AST for stable chunks and EOF" do
+    source = "First **bold**\n\nSecond `code`\n\n- Third\n  - nested **strong**"
+
+    {calls, events} =
+      trace_parser_calls(fn ->
+        Enum.to_list(MDEx.stream([source]))
+      end)
+
+    assert calls == [:parse_document_with_metadata, :parse_document]
+    assert [{0, stable}, {1, _partial}, {1, final}] = events
+    assert stable.nodes == MDEx.parse_document!("First **bold**\n\nSecond `code`\n\n").nodes
+    assert final.nodes == MDEx.parse_document!("- Third\n  - nested **strong**").nodes
+  end
+
+  test "allows each streamed AST to be changed before rendering" do
+    chunks = [
+      "Intro [site](https://example.com/a",
+      ").\n\nRead [the docs].\n\n",
+      "[the docs]: https://example.com/docs\n"
+    ]
+
+    rewrite_links = fn document ->
+      Document.update_nodes(document, MDEx.Link, fn link ->
+        %{link | url: "https://proxy.test/?target=" <> URI.encode_www_form(link.url)}
+      end)
+    end
+
+    transformed_events =
+      chunks
+      |> MDEx.stream()
+      |> Enum.map(fn {id, document} -> {id, rewrite_links.(document)} end)
+
+    expected =
+      chunks
+      |> Enum.join()
+      |> MDEx.parse_document!()
+      |> rewrite_links.()
+      |> MDEx.to_html!()
+
+    assert final_html(transformed_events) == expected
+
+    assert Enum.any?(transformed_events, fn {_id, document} ->
+             MDEx.to_html!(document) =~ "https://proxy.test/?target=https%3A%2F%2Fexample.com%2Fdocs"
+           end)
+  end
+
+  test "runs document plugins on reused stable and EOF ASTs" do
+    rewrite_links = fn document ->
+      Document.append_steps(document,
+        rewrite_links: fn document ->
+          Document.update_nodes(document, MDEx.Link, fn link ->
+            %{link | url: "https://proxy.test/?target=" <> URI.encode_www_form(link.url)}
+          end)
+        end
+      )
+    end
+
+    events =
+      Enum.to_list(
+        MDEx.stream(
+          ["[one](https://example.com/one)\n\n[two](https://example.com/two)"],
+          plugins: [rewrite_links]
+        )
+      )
+
+    assert [{0, stable}, {1, _partial}, {1, final}] = events
+    assert MDEx.to_html!(stable) =~ "target=https%3A%2F%2Fexample.com%2Fone"
+    assert MDEx.to_html!(final) =~ "target=https%3A%2F%2Fexample.com%2Ftwo"
+  end
+
+  test "attaches plugins once and applies their parser options before parsing" do
+    test_process = self()
+
+    plugin = fn document ->
+      send(test_process, :plugin_attached)
+
+      document
+      |> Document.put_extension_options(table: true)
+      |> Document.append_steps(
+        plugin_step: fn document ->
+          send(test_process, :plugin_step_ran)
+          document
+        end
+      )
+    end
+
+    stream =
+      MDEx.stream(
+        ["| A |\n| --- |\n| B |\n\nTail"],
+        plugins: [plugin]
+      )
+
+    refute_received :plugin_attached
+    events = Enum.to_list(stream)
+
+    assert [{0, stable}, {1, _partial}, {1, final}] = events
+    assert MDEx.to_html!(stable) =~ "<table>"
+    assert MDEx.to_html!(final) == "<p>Tail</p>"
+
+    assert_received :plugin_attached
+    refute_received :plugin_attached
+
+    for _event <- events do
+      assert_received :plugin_step_ran
+    end
+
+    refute_received :plugin_step_ran
+  end
+
   defp final_html(events) do
     {ids, documents} =
       Enum.reduce(events, {[], %{}}, fn {id, document}, {ids, documents} ->
@@ -234,5 +343,42 @@ defmodule MDEx.StreamTest do
       end)
 
     Enum.map_join(ids, "\n", fn id -> documents |> Map.fetch!(id) |> MDEx.to_html!() end)
+  end
+
+  defp trace_parser_calls(fun) do
+    Code.ensure_loaded!(MDExNative.Comrak)
+    tracee = self()
+    tracer = spawn_link(fn -> collect_parser_calls([]) end)
+
+    :erlang.trace(tracee, true, [:call, {:tracer, tracer}])
+    :erlang.trace_pattern({MDExNative.Comrak, :parse_document, 2}, true, [:local])
+    :erlang.trace_pattern({MDExNative.Comrak, :parse_document_with_metadata, 2}, true, [:local])
+
+    try do
+      result = fun.()
+      reference = :erlang.trace_delivered(tracee)
+      assert_receive {:trace_delivered, ^tracee, ^reference}
+      send(tracer, {:get_calls, self()})
+      assert_receive {:parser_calls, calls}
+      {calls, result}
+    after
+      :erlang.trace(tracee, false, [:call])
+      :erlang.trace_pattern({MDExNative.Comrak, :parse_document, 2}, false, [:local])
+      :erlang.trace_pattern({MDExNative.Comrak, :parse_document_with_metadata, 2}, false, [:local])
+
+      if Process.alive?(tracer) do
+        Process.exit(tracer, :normal)
+      end
+    end
+  end
+
+  defp collect_parser_calls(calls) do
+    receive do
+      {:trace, _pid, :call, {MDExNative.Comrak, name, _args}} ->
+        collect_parser_calls([name | calls])
+
+      {:get_calls, caller} ->
+        send(caller, {:parser_calls, Enum.reverse(calls)})
+    end
   end
 end

--- a/test/mdex/stream_test.exs
+++ b/test/mdex/stream_test.exs
@@ -1,0 +1,238 @@
+defmodule MDEx.StreamTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureIO
+
+  alias MDEx.Document
+
+  test "deprecates the MDEx.new streaming option while preserving compatibility" do
+    warning =
+      capture_io(:stderr, fn ->
+        document = MDEx.new(streaming: true) |> Document.put_markdown("**partial")
+        assert MDEx.to_html!(document) == "<p><strong>partial</strong></p>"
+      end)
+
+    assert warning =~ "the :streaming option is deprecated"
+    assert warning =~ "MDEx.stream/2"
+  end
+
+  test "returns a native lazy Stream" do
+    parent = self()
+
+    chunks =
+      Stream.resource(
+        fn ->
+          send(parent, :started)
+          ["# One", "\n\nTwo"]
+        end,
+        fn
+          [chunk | rest] -> {[chunk], rest}
+          [] -> {:halt, []}
+        end,
+        fn _state -> send(parent, :closed) end
+      )
+
+    stream = MDEx.stream(chunks)
+
+    assert %Stream{} = stream
+    refute_received :started
+
+    assert [{0, %Document{}}] = Enum.take(stream, 1)
+    assert_received :started
+    assert_received :closed
+  end
+
+  test "emits keyed tail replacements and finalizes at EOF" do
+    events =
+      ["# Hel", "lo\n\nNow **wri", "ting**"]
+      |> MDEx.stream()
+      |> Enum.map(fn {id, document} -> {id, MDEx.to_html!(document)} end)
+
+    assert events == [
+             {0, "<h1>Hel</h1>"},
+             {0, "<h1>Hello</h1>"},
+             {1, "<p>Now <strong>wri</strong></p>"},
+             {1, "<p>Now <strong>writing</strong></p>"},
+             {1, "<p>Now <strong>writing</strong></p>"}
+           ]
+  end
+
+  test "emits no chunks for empty input" do
+    assert [] = Enum.to_list(MDEx.stream([]))
+    assert [] = Enum.to_list(MDEx.stream([""]))
+  end
+
+  test "buffers UTF-8 code points divided across chunks" do
+    events = MDEx.stream(["ol", <<0xC3>>, <<0xA1>>, "\n\n# Next"])
+
+    assert final_html(events) == MDEx.to_html!("olá\n\n# Next")
+  end
+
+  test "raises lazily for incomplete or invalid UTF-8" do
+    incomplete = MDEx.stream(["ol", <<0xC3>>])
+    invalid = MDEx.stream([<<0xFF>>])
+
+    assert %Stream{} = incomplete
+
+    assert_raise ArgumentError, ~r/end-of-input with incomplete UTF-8/, fn ->
+      Enum.to_list(incomplete)
+    end
+
+    assert_raise ArgumentError, ~r/received invalid UTF-8/, fn ->
+      Enum.to_list(invalid)
+    end
+  end
+
+  test "raises lazily when the source emits a non-binary" do
+    stream = MDEx.stream(["valid", :not_a_binary])
+
+    assert_raise ArgumentError, ~r/expected a binary chunk/, fn ->
+      Enum.to_list(stream)
+    end
+  end
+
+  test "can be enumerated again when its source is repeatable" do
+    stream = MDEx.stream(["# One\n\n", "Two"])
+
+    assert Enum.map(stream, &elem(&1, 0)) == Enum.map(stream, &elem(&1, 0))
+    assert final_html(stream) == MDEx.to_html!("# One\n\nTwo")
+  end
+
+  test "stops requesting upstream chunks when downstream halts" do
+    parent = self()
+
+    chunks =
+      Stream.resource(
+        fn -> 0 end,
+        fn
+          0 ->
+            {["**fir"], 1}
+
+          1 ->
+            send(parent, :requested_unseen_chunk)
+            {["st**"], 2}
+
+          2 ->
+            {:halt, 2}
+        end,
+        fn _state -> send(parent, :source_closed) end
+      )
+
+    assert [{0, document}] = chunks |> MDEx.stream() |> Enum.take(1)
+    assert MDEx.to_html!(document) == "<p><strong>fir</strong></p>"
+    refute_received :requested_unseen_chunk
+    assert_received :source_closed
+  end
+
+  test "propagates upstream failures and closes the source" do
+    parent = self()
+
+    chunks =
+      Stream.resource(
+        fn -> 0 end,
+        fn
+          0 -> {["# Started"], 1}
+          1 -> raise "upstream failed"
+        end,
+        fn _state -> send(parent, :source_closed) end
+      )
+
+    assert_raise RuntimeError, "upstream failed", fn ->
+      chunks |> MDEx.stream() |> Enum.to_list()
+    end
+
+    assert_received :source_closed
+  end
+
+  test "applies parser options and preserves final rendering across chunk boundaries" do
+    options = [extension: [strikethrough: true, table: true, tasklist: true]]
+
+    markdown = """
+    # Status
+
+    - [x] ~~prototype~~ Stream
+
+    | API | Value |
+    | --- | --- |
+    | input | Enumerable |
+    """
+
+    chunks = ["# Sta", "tus\n\n- [x] ~~proto", "type~~ Stream\n\n| API |", " Value |\n| --- | --- |\n| input | Enumerable |\n"]
+
+    events = MDEx.stream(chunks, options)
+
+    assert final_html(events) == MDEx.to_html!(markdown, options)
+    assert Enum.all?(events, fn {_id, document} -> document.buffer == [] end)
+  end
+
+  test "matches the final put_markdown document for document-wide constructs" do
+    options = [extension: [table: true]]
+
+    cases = [
+      ["- one\n\n", "- two\n\n"],
+      ["~~~~\nalpha\n\n", "beta\n~~~~\n"],
+      ["Read [the docs].\n\nNext paragraph.\n\n", "[the docs]: https://example.com\n"],
+      ["| Name | Value |\n| --- | --- |\n|", " mdex | Stream |\n"]
+    ]
+
+    for chunks <- cases do
+      document =
+        Enum.reduce(chunks, MDEx.new(options), fn chunk, document ->
+          Document.put_markdown(document, chunk)
+        end)
+        |> Document.run()
+
+      assert final_html(MDEx.stream(chunks, options)) == MDEx.to_html!(document)
+    end
+  end
+
+  test "derives blank block boundaries from parser source positions" do
+    for separator <- ["\n\n", "\n \t\n", "\r\n\r\n", "\r\n \t\r\n"] do
+      events = Enum.to_list(MDEx.stream(["First#{separator}Second"]))
+
+      assert [{0, first}, {1, partial_second}, {1, final_second}] = events
+      assert MDEx.to_html!(first) == "<p>First</p>"
+      assert MDEx.to_html!(partial_second) == "<p>Second</p>"
+      assert MDEx.to_html!(final_second) == "<p>Second</p>"
+      refute Enum.any?(events, fn {_id, document} -> Keyword.has_key?(document.options, :streaming) end)
+    end
+
+    assert [{0, joined}, {0, finalized}] = Enum.to_list(MDEx.stream(["First\nSecond"]))
+    assert MDEx.to_html!(joined) == "<p>First\nSecond</p>"
+    assert MDEx.to_html!(finalized) == "<p>First\nSecond</p>"
+  end
+
+  test "uses parser metadata to hold unresolved reference links without holding task items" do
+    reference_events =
+      Enum.to_list(
+        MDEx.stream([
+          "Stable paragraph.\n\nRead [the docs].\n\n",
+          "[the docs]: https://example.com\n"
+        ])
+      )
+
+    assert [{0, stable}, {1, unresolved}, {1, linked}, {1, final_linked}] = reference_events
+    assert MDEx.to_html!(stable) == "<p>Stable paragraph.</p>"
+    assert MDEx.to_html!(unresolved) == "<p>Read [the docs].</p>"
+    assert MDEx.to_html!(linked) =~ ~s(<a href="https://example.com">the docs</a>)
+    assert MDEx.to_html!(final_linked) == MDEx.to_html!(linked)
+
+    task_events =
+      Enum.to_list(MDEx.stream(["- [x] done\n\nNext"], extension: [tasklist: true]))
+
+    assert [{0, task}, {1, next}, {1, final_next}] = task_events
+    assert MDEx.to_html!(task) =~ ~s(type="checkbox" checked="")
+    assert MDEx.to_html!(next) == "<p>Next</p>"
+    assert MDEx.to_html!(final_next) == "<p>Next</p>"
+  end
+
+  defp final_html(events) do
+    {ids, documents} =
+      Enum.reduce(events, {[], %{}}, fn {id, document}, {ids, documents} ->
+        ids = if Map.has_key?(documents, id), do: ids, else: ids ++ [id]
+        {ids, Map.put(documents, id, document)}
+      end)
+
+    Enum.map_join(ids, "\n", fn id -> documents |> Map.fetch!(id) |> MDEx.to_html!() end)
+  end
+end

--- a/test/mdex/streaming_test.exs
+++ b/test/mdex/streaming_test.exs
@@ -18,7 +18,13 @@ defmodule MDEx.StreamingTest do
   # alias MDEx.TaskItem
   alias MDEx.Text
 
-  defp nodes(chunks, document \\ MDEx.new(streaming: true)) do
+  defp streaming_document(options \\ []) do
+    options
+    |> MDEx.new()
+    |> MDEx.Document.put_private(:fragment_completion, true)
+  end
+
+  defp nodes(chunks, document \\ streaming_document()) do
     Enum.reduce(chunks, document, fn chunk, doc -> Enum.into([chunk], doc) end)
     |> MDEx.Document.run()
     |> Map.get(:nodes)
@@ -371,7 +377,7 @@ defmodule MDEx.StreamingTest do
                  %Strikethrough{nodes: [%Text{literal: "deleted text"}]}
                ]
              }
-           ] = nodes(chunks, MDEx.new(extension: [strikethrough: true], streaming: true))
+           ] = nodes(chunks, streaming_document(extension: [strikethrough: true]))
   end
 
   test "simple insert" do
@@ -386,7 +392,7 @@ defmodule MDEx.StreamingTest do
                  %MDEx.Insert{nodes: [%Text{literal: "inserted text"}]}
                ]
              }
-           ] = nodes(chunks, MDEx.new(extension: [insert: true], streaming: true))
+           ] = nodes(chunks, streaming_document(extension: [insert: true]))
   end
 
   test "simple highlight" do
@@ -401,7 +407,7 @@ defmodule MDEx.StreamingTest do
                  %MDEx.Highlight{nodes: [%Text{literal: "marked text"}]}
                ]
              }
-           ] = nodes(chunks, MDEx.new(extension: [highlight: true], streaming: true))
+           ] = nodes(chunks, streaming_document(extension: [highlight: true]))
   end
 
   test "incomplete insert across chunks" do
@@ -416,7 +422,7 @@ defmodule MDEx.StreamingTest do
                  %MDEx.Insert{nodes: [%Text{literal: "inserted text"}]}
                ]
              }
-           ] = nodes(chunks, MDEx.new(extension: [insert: true], streaming: true))
+           ] = nodes(chunks, streaming_document(extension: [insert: true]))
   end
 
   test "incomplete highlight across chunks" do
@@ -431,7 +437,7 @@ defmodule MDEx.StreamingTest do
                  %MDEx.Highlight{nodes: [%Text{literal: "marked text"}]}
                ]
              }
-           ] = nodes(chunks, MDEx.new(extension: [highlight: true], streaming: true))
+           ] = nodes(chunks, streaming_document(extension: [highlight: true]))
   end
 
   test "simple subtext" do
@@ -446,7 +452,7 @@ defmodule MDEx.StreamingTest do
                  %Text{literal: "Some Subtext"}
                ]
              }
-           ] = nodes(chunks, MDEx.new(extension: [subtext: true], streaming: true))
+           ] = nodes(chunks, streaming_document(extension: [subtext: true]))
   end
 
   test "bold emphasis across chunks" do
@@ -833,7 +839,7 @@ defmodule MDEx.StreamingTest do
                num_rows: 1,
                num_nonempty_cells: 2
              }
-           ] = nodes(chunks, MDEx.new(extension: [table: true], streaming: true))
+           ] = nodes(chunks, streaming_document(extension: [table: true]))
   end
 
   test "table with incomplete header separator" do
@@ -858,7 +864,7 @@ defmodule MDEx.StreamingTest do
                num_rows: 1,
                num_nonempty_cells: 2
              }
-           ] = nodes(chunks, MDEx.new(extension: [table: true], streaming: true))
+           ] = nodes(chunks, streaming_document(extension: [table: true]))
   end
 
   test "table with incomplete row" do
@@ -891,7 +897,7 @@ defmodule MDEx.StreamingTest do
                num_rows: 2,
                num_nonempty_cells: 4
              }
-           ] = nodes(chunks, MDEx.new(extension: [table: true], streaming: true))
+           ] = nodes(chunks, streaming_document(extension: [table: true]))
   end
 
   # FIXME
@@ -927,8 +933,7 @@ defmodule MDEx.StreamingTest do
 
     options = [
       extension: [tasklist: true],
-      parse: [relaxed_tasklist_matching: true],
-      streaming: true
+      parse: [relaxed_tasklist_matching: true]
     ]
 
     assert [
@@ -961,14 +966,13 @@ defmodule MDEx.StreamingTest do
                  }
                ]
              }
-           ] = nodes(chunks, MDEx.new(options))
+           ] = nodes(chunks, streaming_document(options))
   end
 
   test "task list retains emphasis across chunks" do
     options = [
       extension: [tasklist: true],
-      parse: [relaxed_tasklist_matching: true],
-      streaming: true
+      parse: [relaxed_tasklist_matching: true]
     ]
 
     chunks = [
@@ -1045,7 +1049,7 @@ defmodule MDEx.StreamingTest do
                  %Text{literal: " for specs"}
                ]
              }
-           ] = nodes(chunks, MDEx.new(extension: [autolink: true], streaming: true))
+           ] = nodes(chunks, streaming_document(extension: [autolink: true]))
   end
 
   test "line breaks with trailing spaces" do
@@ -1198,7 +1202,7 @@ defmodule MDEx.StreamingTest do
     end
 
     test "fragment state tracks unclosed token across flushes" do
-      doc = MDEx.new(streaming: true)
+      doc = streaming_document()
 
       # First flush: ** opens bold, FragmentParser completes it
       doc = Enum.into(["**bold "], doc) |> MDEx.Document.run()
@@ -1212,7 +1216,7 @@ defmodule MDEx.StreamingTest do
              ] =
                multi_flush_nodes(
                  ["[click](https://example.com) ", "more text"],
-                 MDEx.new(streaming: true)
+                 streaming_document()
                )
 
       assert %MDEx.Link{url: "https://example.com"} = hd(nodes)
@@ -1225,7 +1229,7 @@ defmodule MDEx.StreamingTest do
              ] =
                multi_flush_nodes(
                  ["```\nhello\n```\n", "after"],
-                 MDEx.new(streaming: true)
+                 streaming_document()
                )
     end
 
@@ -1235,7 +1239,7 @@ defmodule MDEx.StreamingTest do
              ] =
                multi_flush_nodes(
                  ["Hello ", "world ", "!"],
-                 MDEx.new(streaming: true)
+                 streaming_document()
                )
 
       text =
@@ -1254,7 +1258,7 @@ defmodule MDEx.StreamingTest do
              ] =
                multi_flush_nodes(
                  ["<div>foo", "bar</div>"],
-                 MDEx.new(streaming: true)
+                 streaming_document()
                )
     end
 
@@ -1264,7 +1268,7 @@ defmodule MDEx.StreamingTest do
              ] =
                multi_flush_nodes(
                  ["<div", ">foo<", "/div>"],
-                 MDEx.new(streaming: true)
+                 streaming_document()
                )
     end
 
@@ -1274,7 +1278,7 @@ defmodule MDEx.StreamingTest do
              ] =
                multi_flush_nodes(
                  ["# Tit", "le"],
-                 MDEx.new(streaming: true)
+                 streaming_document()
                )
     end
   end

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -415,6 +415,15 @@ Use `MDEx.stream/2` for LLM, SSE, file, or HTTP response chunks.
 - Replace a chunk when its id repeats.
 - After a higher id appears, all lower ids are stable.
 - Render each document. MDEx closes partial syntax for the open chunk.
+- Change the emitted AST before rendering when the transform only needs one
+  keyed document.
+- Do not assume an emitted document contains the full Markdown response.
+- Plugins attach once when Stream enumeration starts. Their pipeline steps run
+  on every emitted document, including repeated ids.
+- Plugin parser options apply before parsing, but plugin steps remain local to
+  one keyed document.
+- Do not use a plugin that preprocesses `document.buffer` with
+  `MDEx.stream/2`. Use the one-document API after collecting the full source.
 - Use normal Stream completion as EOF.
 
 ```elixir

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -1,8 +1,9 @@
 # MDEx Usage Rules
 
-MDEx is a fast, extensible Markdown library for Elixir. It parses Markdown into an AST (`MDEx.Document`) and renders to HTML, HEEx, JSON, XML, normalized Markdown, or Quill Delta.
+MDEx parses Markdown into an AST (`MDEx.Document`). It can render HTML, HEEx,
+JSON, XML, CommonMark, or Quill Delta.
 
-This file is the source of truth for coding agents working with MDEx.
+This file gives API rules for developers and coding agents.
 
 ## Agent Defaults
 
@@ -10,7 +11,7 @@ This file is the source of truth for coding agents working with MDEx.
 2. **Use `use MDEx` in modules that render Markdown** - It adds `require MDEx` and `import MDEx.Sigil`.
 3. **Use `HEEX` only when you need Phoenix semantics** - Components, `phx-*`, `{@assigns}`, or HEEx expressions.
 4. **Use runtime functions for runtime content** - Database content, user input, files, API responses, LLM output.
-5. **Use `MDEx.Document` when you need control** - AST transforms, plugins, streaming, custom renderers, inspection.
+5. **Use `MDEx.Document` when you need control** - AST transforms, plugins, custom renderers, inspection.
 6. **Keep options explicit and minimal** - Only enable extensions and unsafe rendering when needed.
 
 ## Decision Guide
@@ -68,17 +69,18 @@ MDEx.to_html!(doc)
 
 ### Streaming or chunked Markdown
 
-- Use `MDEx.new(streaming: true)`.
-- Append chunks with `MDEx.Document.put_markdown/2` or `Enum.into/2`.
-- Render after each chunk with `MDEx.to_html!/1` or another `to_*` function.
+- Pass the source Enumerable to `MDEx.stream/2`.
+- Read `{id, %MDEx.Document{}}` chunks.
+- Insert a new id and replace a repeated id.
+- Treat all lower ids as stable after a higher id appears.
+- Treat normal Stream completion as EOF.
 
 ```elixir
-doc = MDEx.new(streaming: true)
-doc = MDEx.Document.put_markdown(doc, "**Hel")
-html = MDEx.to_html!(doc)
-
-doc = MDEx.Document.put_markdown(doc, "lo**")
-html = MDEx.to_html!(doc)
+chunks
+|> MDEx.stream(extension: [table: true])
+|> Enum.each(fn {id, document} ->
+  replace_rendered_chunk(id, MDEx.to_html!(document))
+end)
 ```
 
 ## Canonical API Choices
@@ -180,7 +182,8 @@ Treat this API as experimental.
 
 ### `MDEx.new/1`
 
-Use this as the entrypoint for pipelines, plugins, streaming, assigns, and reusable option sets.
+Use this as the entry point for document pipelines, plugins, assigns, and
+shared option sets. Use `MDEx.stream/2` for an Enumerable of Markdown chunks.
 
 ```elixir
 doc =
@@ -405,20 +408,26 @@ Use `document.private` helpers for plugin state instead of overloading assigns.
 
 ## Streaming Rules
 
-Streaming mode is especially useful for LLM or SSE output.
+Use `MDEx.stream/2` for LLM, SSE, file, or HTTP response chunks.
 
-- Always set `streaming: true` on document creation.
-- Keep the same document instance across chunks.
-- `put_markdown/2` appends chunks to the document buffer.
-- `Enum.into(chunks, doc)` is the cleanest way to accumulate many chunks.
-- Any `to_*` call flushes the buffer, completes open syntax temporarily, and re-renders.
+- Pass any Enumerable of binary chunks directly to `MDEx.stream/2`.
+- Insert a chunk when its id is new.
+- Replace a chunk when its id repeats.
+- After a higher id appears, all lower ids are stable.
+- Render each document. MDEx closes partial syntax for the open chunk.
+- Use normal Stream completion as EOF.
 
 ```elixir
-doc = Enum.into(["# Hel", "lo\n\n", "**world**"], MDEx.new(streaming: true))
-html = MDEx.to_html!(doc)
+["# Hel", "lo\n\n", "**world**"]
+|> MDEx.stream()
+|> Enum.each(fn {id, document} ->
+  replace_rendered_chunk(id, MDEx.to_html!(document))
+end)
 ```
 
-If you want to replace prior content instead of appending, create a fresh document.
+`MDEx.new(streaming: true)` is deprecated. Use `MDEx.new/1` and
+`MDEx.Document.put_markdown/3` to build one document in steps. Do not use them
+as a manual streaming API.
 
 ## Output Formats
 
@@ -580,7 +589,7 @@ doc = MDEx.Document.wrap(%MDEx.Text{literal: "Hello"})
 5. **Forgetting required extensions** - Tables, strikethrough, math, footnotes, and similar syntax need explicit options unless a plugin enables them.
 6. **Treating `parse_fragment!/1` like a full document parser** - It is for one fragment node.
 7. **Expecting component imports to be automatic in HEEx** - Import or fully qualify them yourself.
-8. **Replacing streaming content with `put_markdown/2`** - It appends; create a new document if you want replacement.
+8. **Using `MDEx.new(streaming: true)`** - It is deprecated; pass chunks to `MDEx.stream/2`.
 9. **Putting inline nodes at the root** - Wrap them in a block container.
 10. **Using plugins without attaching or passing them** - They do nothing until attached.
 
@@ -600,7 +609,8 @@ Use `MDEx.to_html!/2` and consider sanitization if raw HTML is enabled.
 
 ### LLM chat output
 
-Use `MDEx.new(streaming: true)` and keep the document in state between chunks.
+Pass the provider's text chunks through `MDEx.stream/2`. Insert new ids and
+replace repeated ids.
 
 ### Reusable Markdown processing pipeline
 


### PR DESCRIPTION
## Summary

- add lazy `MDEx.stream/2` support for any enumerable of binary Markdown chunks
- emit keyed `%MDEx.Document{}` values that work with Phoenix LiveView streams
- reuse parsed ASTs for stable chunks and at end of stream, while reparsing only the open fragment
- preserve parser options and plugin behavior, and deprecate `MDEx.new(streaming: true)`
- add a Req -> MDEx -> LiveView streaming example with Lumis syntax highlighting, adjustable delay, auto-scroll, and runtime metrics
- document AST transforms, plugin behavior, and the whole-document limitation
- validate the API locally with Loopyard, phoenix_streamdown, and Ash AI

## Dependency

This PR is a draft because it requires `MDExNative.Comrak.parse_document_with_metadata/2`, planned for mdex_native 0.2.10. The native implementation is currently local and uncommitted, and is not part of this PR.

Default CI cannot resolve `mdex_native >= 0.2.10` until that package is released.

## Validation

- `mix compile --warnings-as-errors` with the local mdex_native implementation
- `mix test` with the local mdex_native implementation: 818 passed (62 doctests and 756 tests)
- `mix docs --warnings-as-errors`
- Phoenix Playground integration tests: 2 passed, including the default raw GitHub README URL
- current mdex_gfm source streamed with a GFM table
- Loopyard: 1,901 tests passed; 122 environment-dependent tests excluded
- phoenix_streamdown: `mix ci` passed with 24 tests; example passed with 8 tests
- Ash AI: 351 tests passed; 28 tests excluded

The client branches remain local and uncommitted.
