### PR TITLE
ci: enforce cyclomatic complexity ceiling with strict linting

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -1,10 +1,32 @@
+# Credo runs in strict mode, so `mix credo` locally reports exactly what CI
+# reports. The settings below are the ones this repository pins on purpose;
+# everything else is Credo's own default.
 %{
   configs: [
     %{
       name: "default",
-      checks: [
-        {Credo.Check.Design.TagTODO, false}
-      ]
+      strict: true,
+      files: %{
+        included: ["lib/", "src/", "test/", "config/", "mix.exs"],
+        excluded: [~r"/_build/", ~r"/deps/", ~r"/node_modules/"]
+      },
+      checks: %{
+        extra: [
+          # Classic McCabe cyclomatic complexity, at the ceiling shared by every
+          # project in this family, in Elixir and in JavaScript alike.
+          {Credo.Check.Refactor.CyclomaticComplexity, max_complexity: 9},
+          # Credo's strict default, or `line_length` from .formatter.exs where
+          # that is larger, so the formatter and the linter cannot disagree about
+          # a line the formatter itself produced.
+          {Credo.Check.Readability.MaxLineLength, max_length: 150}
+        ],
+        disabled: [
+          # TODO and FIXME notes are tracked in the issue tracker. Failing a
+          # build on one only encourages deleting the note.
+          {Credo.Check.Design.TagTODO, []},
+          {Credo.Check.Design.TagFIXME, []}
+        ]
+      }
     }
   ]
 }

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -16,3 +16,4 @@ jobs:
     uses: leandrocp/github-actions/.github/workflows/elixir-lint.yml@main
     with:
       credo: true
+      credo_args: '--strict'

--- a/lib/mdex.ex
+++ b/lib/mdex.ex
@@ -34,8 +34,8 @@ defmodule MDEx do
              |> Kernel.<>(@inner_moduledoc)
 
   alias MDEx.ComrakConverter
-  alias MDEx.Document
   alias MDEx.DecodeError
+  alias MDEx.Document
   alias MDEx.InvalidInputError
   alias MDEx.SlackConverter
   alias MDExNative.Comrak
@@ -540,6 +540,9 @@ defmodule MDEx do
     opts = [file: caller.file, line: caller.line + 1, caller: caller, tag_handler: Phoenix.LiveView.HTMLEngine]
 
     if function_exported?(Phoenix.LiveView.TagEngine, :compile, 2) do
+      # `apply/3` is what keeps this compiling against the LiveView versions
+      # that do not export `compile/2`; a direct call would not.
+      # credo:disable-for-next-line Credo.Check.Refactor.Apply
       apply(Phoenix.LiveView.TagEngine, :compile, [html, opts])
     else
       EEx.compile_string(

--- a/lib/mdex/delta_converter.ex
+++ b/lib/mdex/delta_converter.ex
@@ -29,16 +29,14 @@ defmodule MDEx.DeltaConverter do
   """
   @spec convert(Document.t(), options()) :: {:ok, [delta_op()]} | {:error, term()}
   def convert(%Document{nodes: nodes}, options) do
-    try do
-      # Initialize list_depth if not provided
-      options = Keyword.put_new(options, :list_depth, 0)
-      ops = convert_nodes(nodes, [], options)
-      {:ok, ops}
-    rescue
-      error -> {:error, error}
-    catch
-      error -> {:error, error}
-    end
+    # Initialize list_depth if not provided
+    options = Keyword.put_new(options, :list_depth, 0)
+    ops = convert_nodes(nodes, [], options)
+    {:ok, ops}
+  rescue
+    error -> {:error, error}
+  catch
+    error -> {:error, error}
   end
 
   # Convert a list of nodes, accumulating operations and current formatting state

--- a/lib/mdex/document.ex
+++ b/lib/mdex/document.ex
@@ -674,6 +674,7 @@ defmodule MDEx.Document do
   @behaviour Access
   alias __MODULE__
   alias MDEx.ComrakConverter
+  alias MDEx.Document.Traversal
   alias MDExNative.Comrak
 
   @built_in_options [
@@ -2445,7 +2446,7 @@ defmodule MDEx.Document do
   def update_nodes(%MDEx.Document{} = document, selector, fun) when is_function(fun, 1) do
     # document = maybe_resolve_document(document)
 
-    MDEx.Document.Traversal.traverse_and_update(document, fn node ->
+    Traversal.traverse_and_update(document, fn node ->
       if match_selector?(node, selector) do
         fun.(node)
       else
@@ -3826,6 +3827,9 @@ defimpl Inspect, for: MDEx.Document do
               field != :__exception__,
               do: map
 
+        # credo:disable-for-lines:12 Credo.Check.Refactor.Apply
+        # `apply/3` is what keeps this compiling against the Elixir versions
+        # that export only one of these two private Inspect helpers.
         if function_exported?(Inspect.Map, :inspect, 4) do
           apply(Inspect.Map, :inspect, [document, inspect(document.__struct__), infos, opts])
         else

--- a/lib/mdex/document/access.ex
+++ b/lib/mdex/document/access.ex
@@ -1,6 +1,8 @@
 defmodule MDEx.Document.Access do
   @moduledoc false
 
+  alias MDEx.Document.Traversal
+
   defmacro __using__(_opts) do
     quote do
       @doc false
@@ -48,7 +50,7 @@ defmodule MDEx.Document.Access do
 
   def get_and_update(document, selector, fun) when is_struct(selector) do
     {document, {_, old}} =
-      MDEx.Document.Traversal.traverse_and_update(document, {:cont, nil}, fn
+      Traversal.traverse_and_update(document, {:cont, nil}, fn
         node, {:halted, old} ->
           {node, {:halted, old}}
 
@@ -68,7 +70,7 @@ defmodule MDEx.Document.Access do
     selector = modulefy!(selector)
 
     {document, {_, old}} =
-      MDEx.Document.Traversal.traverse_and_update(document, {:cont, nil}, fn
+      Traversal.traverse_and_update(document, {:cont, nil}, fn
         node, {:halted, old} ->
           {node, {:halted, old}}
 
@@ -89,7 +91,7 @@ defmodule MDEx.Document.Access do
 
   def get_and_update(document, selector, fun) when is_function(selector) do
     {document, {_, old}} =
-      MDEx.Document.Traversal.traverse_and_update(document, {:cont, nil}, fn
+      Traversal.traverse_and_update(document, {:cont, nil}, fn
         node, {:halted, old} ->
           {node, {:halted, old}}
 
@@ -120,7 +122,7 @@ defmodule MDEx.Document.Access do
 
   def pop(document, key, default) when is_struct(key) do
     {new, {_, old}} =
-      MDEx.Document.Traversal.traverse_and_update(document, {:cont, nil}, fn
+      Traversal.traverse_and_update(document, {:cont, nil}, fn
         node, {:halted, old} ->
           {node, {:halted, old}}
 
@@ -139,7 +141,7 @@ defmodule MDEx.Document.Access do
     key = modulefy!(key)
 
     {new, {_, old}} =
-      MDEx.Document.Traversal.traverse_and_update(document, {:cont, nil}, fn
+      Traversal.traverse_and_update(document, {:cont, nil}, fn
         node, {:halted, old} ->
           {node, {:halted, old}}
 

--- a/test/mdex/delta_converter_test.exs
+++ b/test/mdex/delta_converter_test.exs
@@ -138,7 +138,7 @@ defmodule MDEx.DeltaConverterTest do
                %{"insert" => "\n"},
                # Extra spacing before empty paragraph
                %{"insert" => "\n"},
-               # Empty paragraph 
+               # Empty paragraph
                %{"insert" => "\n"},
                # Extra spacing before next paragraph
                %{"insert" => "\n"},

--- a/test/mdex/sigil_test.exs
+++ b/test/mdex/sigil_test.exs
@@ -2,6 +2,7 @@ defmodule MDEx.SigilTest do
   use ExUnit.Case, async: true
   import MDEx.Sigil
   alias MDEx.Code
+  alias Phoenix.HTML.Safe
 
   defmodule WithLegacyLumis do
     use MDEx, syntax_highlight: [formatter: :html_inline]
@@ -31,7 +32,7 @@ defmodule MDEx.SigilTest do
                ]
              },
              _
-           } = Elixir.Code.eval_string("import MDEx.Sigil\n~MD\"\"\"\n# Hello\n\"\"\"")
+           } = Elixir.Code.eval_string(~s(import MDEx.Sigil\n~MD"""\n# Hello\n"""))
   end
 
   describe "sigil_MD with assigns" do
@@ -64,7 +65,7 @@ defmodule MDEx.SigilTest do
         {:ok, %{name: "MDEx"}}
         ```
         '''HEEX
-        |> Phoenix.HTML.Safe.to_iodata()
+        |> Safe.to_iodata()
         |> IO.iodata_to_binary()
 
       assert html =~ "%&lbrace;&rbrace;"

--- a/test/mdex/slack_converter_test.exs
+++ b/test/mdex/slack_converter_test.exs
@@ -1,8 +1,8 @@
 defmodule MDEx.SlackConverterTest do
   use ExUnit.Case
 
-  alias MDEx.SlackConverter
   alias MDEx.Document
+  alias MDEx.SlackConverter
 
   describe "convert/2" do
     test "converts empty document" do

--- a/test/mdex_test.exs
+++ b/test/mdex_test.exs
@@ -1094,7 +1094,7 @@ defmodule MDExTest do
 
     test "enable all by default" do
       assert MDEx.safe_html(
-               "<span>{:example} <code class=\"lang-ex\" data-foo=\"{:val}\">{:ok, 'foo'}</code></span><script>console.log('hello')</script>"
+               ~s|<span>{:example} <code class="lang-ex" data-foo="{:val}">{:ok, 'foo'}</code></span><script>console.log('hello')</script>|
              ) ==
                "&lt;span&gt;{:example} &lt;code class=&quot;lang-ex&quot;&gt;&lbrace;:ok, &#x27;foo&#x27;&rbrace;&lt;&#x2f;code&gt;&lt;&#x2f;span&gt;"
     end


### PR DESCRIPTION
Adds a cyclomatic complexity ceiling and turns the linter up to strict, so both
run on every push and pull request. Part of applying one complexity standard
across the projects in this family.

## What this enforces

- `.credo.exs` pins `Credo.Check.Refactor.CyclomaticComplexity` at **max 9** —
  classic McCabe, the same metric and ceiling that oxlint's `eslint/complexity`
  enforces on the JavaScript in the sibling repositories.
- `strict: true` lives in the config rather than only in the CI invocation, so a
  local `mix credo` reports exactly what CI reports.
- `Credo.Check.Readability.MaxLineLength` is set to Credo's strict default of
  120, or to `.formatter.exs`'s `line_length` where that is larger, so the
  formatter and the linter cannot disagree about a line the formatter produced.
- `Credo.Check.Design.TagTODO` / `TagFIXME` are off. Those notes belong in the
  issue tracker; failing a build on one only encourages deleting the note.

## CI

The `lint` job now passes `credo: true` and `credo_args: '--strict'` to the
shared `elixir-lint.yml` workflow.

`credo` already ran here; it now runs with `--strict`, and the config that
previously only switched off `TagTODO` now states the complexity ceiling
explicitly.

## Code changes

- `MDEx.DeltaConverter.convert/2` wrapped its whole body in an explicit `try`;
  it now uses the implicit function-level `rescue`/`catch`.
- `MDEx.Document` and `MDEx.Document.Access` called
  `MDEx.Document.Traversal.traverse_and_update/2,3` fully qualified at six
  sites; `Traversal` is now aliased in both.
- `MDEx.SigilTest` aliases `Phoenix.HTML.Safe`.
- Alias groups in `MDEx` and `MDEx.SlackConverterTest` are alphabetically
  ordered.
- Two test strings with four or more escaped quotes became `~s` sigils, and one
  trailing space was removed.
- The two `apply/3` calls that exist to stay compatible with Elixir and
  LiveView versions that export a different function are annotated with
  `credo:disable-for-next-line` and a comment saying why a direct call will not
  do.

Verified with `mix credo --strict` (clean) and `mix test` (801 passed).
