### PR TITLE
ci: skip CodeRabbit reviews for release PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+reviews:
+  auto_review:
+    ignore_title_keywords:
+      - "chore: release"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,4 +3,4 @@
 reviews:
   auto_review:
     ignore_title_keywords:
-      - "chore: release"
+      - "chore: release v"


### PR DESCRIPTION
## Summary

- add a repository-level CodeRabbit configuration
- skip automatic reviews for generated `chore: release v…` pull requests

## Validation

- parsed `.coderabbit.yaml` successfully
- verified `ignore_title_keywords` against CodeRabbit's v2 schema
- confirmed the generated release title matches the configured keyword
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated code review configuration.
  * Pull requests with titles containing “chore: release v” are excluded from automated reviews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->