### PR TITLE
fix(parser): do not append a table row when a blank line closed the table

### DIFF
--- a/lib/mdex/fragment_parser.ex
+++ b/lib/mdex/fragment_parser.ex
@@ -456,10 +456,10 @@ defmodule MDEx.FragmentParser do
 
   defp maybe_complete_table(core, trailing) do
     case trailing do
-      <<?\n, _::binary>> ->
+      <<?\n, rest::binary>> ->
         line = last_line(core)
 
-        if table_header_line?(line) do
+        if table_header_line?(line) and not blank_line_follows?(rest) do
           separator = generate_table_separator(line)
           {core <> "\n" <> separator, {:consume_trailing, "\n"}}
         else
@@ -470,6 +470,8 @@ defmodule MDEx.FragmentParser do
         nil
     end
   end
+
+  defp blank_line_follows?(rest), do: :binary.match(rest, "\n") != :nomatch
 
   defp table_header_line?(line) do
     trimmed = String.trim(line)

--- a/test/mdex/fragment_parser_test.exs
+++ b/test/mdex/fragment_parser_test.exs
@@ -217,6 +217,22 @@ defmodule MDEx.FragmentParserTest do
     assert complete("| foo | bar |\n") == "| foo | bar |\n| - | - |"
   end
 
+  test "table closed by blank line" do
+    assert complete("| a |\n|---|\n| 1 |\n\n") == "| a |\n|---|\n| 1 |\n\n"
+  end
+
+  test "multi column table closed by blank line" do
+    assert complete("| a | b |\n|---|---|\n| 1 | 2 |\n\n") == "| a | b |\n|---|---|\n| 1 | 2 |\n\n"
+  end
+
+  test "table closed by blank line after other blocks" do
+    assert complete("# h\n\n| a |\n|---|\n| 1 |\n\n") == "# h\n\n| a |\n|---|\n| 1 |\n\n"
+  end
+
+  test "open table still gets a row appended" do
+    assert complete("| a |\n|---|\n| 1 |\n") == "| a |\n|---|\n| 1 |\n| - |"
+  end
+
   test "- [x] Collect *n" do
     assert complete("- [x] Collect *n") == "- [x] Collect *n*"
   end


### PR DESCRIPTION
## The bug

`MDEx.FragmentParser.complete/2` appended a phantom `| - |` row to a table that had already been closed by a trailing blank line.

`maybe_complete_table/2` only checked that the trailing whitespace *starts* with `\n`. It never looked at the rest, so `"...| 1 |\n\n"` was treated the same as `"...| 1 |\n"` — an open table still being streamed.

Reproducer on `main`:

```elixir
MDEx.FragmentParser.complete("| a |\n|---|\n| 1 |\n\n")
#=> "| a |\n|---|\n| 1 |\n| - |\n"    # phantom row

MDEx.FragmentParser.complete("| a | b |\n|---|---|\n| 1 | 2 |\n\n")
#=> "| a | b |\n|---|---|\n| 1 | 2 |\n| - | - |\n"

MDEx.FragmentParser.complete("# h\n\n| a |\n|---|\n| 1 |\n\n")
#=> "# h\n\n| a |\n|---|\n| 1 |\n| - |\n"
```

During streaming this meant every table rendered with an extra empty row until the end of input.

## The change

`maybe_complete_table/2` now bails out when the trailing whitespace contains a second newline, i.e. a blank line closed the block.

A table whose source ends immediately after a row (no blank line) is still considered open and keeps the existing behaviour of getting a separator/row appended.

## Tests

Four regression tests in `test/mdex/fragment_parser_test.exs` covering the closed-by-blank-line cases (single column, multi column, after another block) plus an assertion that the still-open case is unchanged. Suite goes from 825 to 829 passing; no existing test asserted the old output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown table completion to avoid adding separator rows when a blank line follows the table.
  * Continued completing open tables that are not followed by a blank line.
  * Improved handling of single-column, multi-column, and tables following other content.

* **Tests**
  * Added coverage for table completion behavior around blank-line boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->