### PR TITLE
feat: add :auto_close option to close open Markdown syntax

### DIFF
--- a/guides/streaming.md
+++ b/guides/streaming.md
@@ -1,253 +1,184 @@
 # Streaming Markdown
 
-Use `MDEx.stream/2` when Markdown arrives in chunks from an LLM, file, or HTTP
-response.
+Two independent things are involved when Markdown arrives a piece at a time:
+
+- **`MDEx.stream/2`** turns an Enumerable of chunks into keyed documents, so a UI
+  updates only what changed.
+- **`:auto_close`** closes Markdown syntax left open at the end of the source, so
+  a half-written `**bold` renders as bold instead of literal asterisks. It is an
+  option on every render, and on by default in `MDEx.stream/2`.
+
+Use either on its own. If you already hold the whole response as a string and
+only want it to render sensibly while it grows, you want `:auto_close`, not
+`MDEx.stream/2`.
+
+## `:auto_close`
 
 ```elixir
-chunks
-|> MDEx.stream(options)
-|> Enum.each(&consume/1)
+MDEx.to_html!("Some **bo")                     #=> "<p>Some **bo</p>"
+MDEx.to_html!("Some **bo", auto_close: true)   #=> "<p>Some <strong>bo</strong></p>"
 ```
 
-The input is any `Enumerable` of binaries. The result is a lazy Elixir
-`Stream`. MDEx parses each update and emits keyed documents:
+It closes emphasis, inline code, fenced blocks, links, images, tables, list
+markers, and HTML tags. It works with every renderer and with
+`MDEx.parse_document/2`, so AST transforms on partial source are possible too.
+
+The trade-off is that a link whose URL is still arriving renders as a real link:
 
 ```elixir
-{id, %MDEx.Document{}}
+MDEx.to_html!("a [x](htt", auto_close: true)   #=> ~s(<p>a <a href="htt">x</a></p>)
 ```
 
-The caller does not need to manage parser state.
+Pass `auto_close: false` if you would rather show the raw source until the
+construct is finished, including inside `MDEx.stream/2`.
 
-## Output contract
+## `MDEx.stream/2`
 
-Each document is parsed and ready to render. Render it in the format your
-application needs:
+The input is any `Enumerable` of binaries. The result is a lazy `Stream` of
+`{id, %MDEx.Document{}}`. You do not manage parser state.
 
 ```elixir
 chunks
 |> MDEx.stream(extension: [table: true])
-|> Stream.map(fn {id, document} ->
-  {id, MDEx.to_html!(document)}
+|> Enum.each(fn {id, document} ->
+  replace_rendered_chunk(id, MDEx.to_html!(document))
 end)
-|> Enum.each(&update_output/1)
 ```
 
 An id may appear more than once:
 
 ```elixir
-{0, first_document}         # insert
-{1, partial_document}       # insert
-{0, updated_first_document} # replace an earlier chunk
-{1, final_document}         # replace at EOF if the normal AST differs
+{0, first}    # insert
+{1, partial}  # insert
+{0, revised}  # replace an earlier chunk
+{1, final}    # replace at EOF if the AST changed
 ```
 
-Apply these rules:
-
 1. Insert a chunk when its id is new.
-2. Replace a chunk when its id repeats.
-3. Keep chunks in id order. A replacement does not move its chunk.
-4. Any earlier id may repeat. Document-wide Markdown can change an earlier AST.
-5. Normal Stream completion is EOF. There is no custom EOF chunk or unchanged
-   replacement.
+2. Replace a chunk when its id repeats. A replacement does not move it.
+3. Any earlier id may repeat — a late link reference or footnote definition
+   changes a block that was already emitted.
+4. Normal Stream completion is EOF. There is no EOF chunk.
 
-A chunk may contain more than one Markdown block. MDEx groups top-level nodes
-by source range so consumers do not need to split Markdown themselves.
-When raw HTML opens a container across Markdown blocks, MDEx keeps the whole
-container in one keyed chunk. This keeps keyed DOM children independent when
-`render: [unsafe: true]` is enabled.
+MDEx groups top-level nodes by source range, so a chunk may hold more than one
+Markdown block and you never split Markdown yourself. Raw HTML that opens a
+container across blocks stays in one keyed chunk. Emitted documents are
+immutable. If the consumer stops early, MDEx does not read input it has not
+reached.
 
-MDEx emits a new immutable document for each update. It does not change a
-document that it already emitted.
+### Collecting the final output
 
-If the consumer stops early, MDEx does not parse input it has not read.
-
-## Collect the final output
-
-Without a live UI, collect the latest document for each id and join them in
-order:
+Keep the latest document per id and join them in order:
 
 ```elixir
 html =
   chunks
   |> MDEx.stream()
-  |> Stream.map(fn {id, document} ->
-    {id, MDEx.to_html!(document)}
-  end)
+  |> Stream.map(fn {id, document} -> {id, MDEx.to_html!(document)} end)
   |> Enum.into(%{})
   |> Enum.sort_by(&elem(&1, 0))
   |> Enum.map_join("\n", &elem(&1, 1))
 ```
 
-## Change the AST before rendering
+### Transforming before rendering
 
-Each emitted `%MDEx.Document{}` contains a parsed AST. You can change its nodes
-before rendering it. Do not call `MDEx.parse_document!/2` again.
-
-This example sends external links through a redirect service:
+Each emitted document holds a parsed AST — change it, do not parse it again:
 
 ```elixir
-def rewrite_links(document) do
-  MDEx.Document.update_nodes(document, MDEx.Link, fn link ->
-    url = "https://example.test/redirect?to=" <> URI.encode_www_form(link.url)
-    %{link | url: url}
-  end)
-end
-
 chunks
 |> MDEx.stream()
-|> Stream.map(fn {id, document} ->
-  document = rewrite_links(document)
-  {id, MDEx.to_html!(document)}
-end)
+|> Stream.map(fn {id, document} -> {id, MDEx.to_html!(rewrite_links(document))} end)
 |> Enum.each(&update_output/1)
 ```
 
-Apply the transform to every emitted chunk, including repeated ids. A partial
-link may become a complete link in a later update with the same id. A reference
-link may also become available after its definition arrives.
+Apply the transform to every emitted chunk, including repeated ids.
 
-### Whole-document limit
+A chunk is one keyed segment, not the whole response. Transforms that need the
+whole document — a table of contents, ids unique across the response, numbering
+shared by several chunks — need the complete source, or state you keep yourself
+and reconcile when an id repeats.
 
-The document in `{id, document}` is one keyed chunk, not the full Markdown
-response. A transform that only needs nodes in that chunk, such as rewriting a
-link or adding attributes, works directly.
+## Sources
 
-A transform that needs all content may produce a different result. Examples
-include a table of contents, heading ids that must be unique across the whole
-response, and numbering shared by several chunks. For those transforms, either
-wait for the full source or keep state outside MDEx and account for any
-repeated id.
-
-## Lists and generated streams
+`File.stream!/1`, `Req`'s async body, and any other Enumerable work directly:
 
 ```elixir
-["# Hel", "lo\n\n", "Some **bold", " text**"]
-|> MDEx.stream()
-|> Stream.each(fn {_id, document} ->
-  IO.write(MDEx.to_html!(document))
-end)
-|> Stream.run()
+"README.md" |> File.stream!([], 2048) |> MDEx.stream()
+
+Req.get!(url, into: :self).body |> MDEx.stream(extension: [table: true])
 ```
 
-You can use normal `Stream` functions before and after `MDEx.stream/2`:
+Req cancels the request if the consumer stops early.
+
+A chunk may split a UTF-8 code point. MDEx holds the incomplete bytes until the
+next chunk. Invalid UTF-8 raises when the Stream reaches it, and so does an
+incomplete code point at EOF.
+
+### Sources that push
+
+`MDEx.stream/2` pulls. When a source pushes instead — process messages, a
+callback, PubSub fan-out — adapt it at the application boundary with
+`Stream.resource/3`, and read it in a task rather than in a process that must
+stay responsive:
 
 ```elixir
-chunk_source
-|> MDEx.stream(options)
-|> Stream.map(fn {id, document} ->
-  {id, MDEx.to_json!(document)}
-end)
-|> Stream.filter(&interesting?/1)
-|> Enum.each(&publish/1)
+def new(source) do
+  Stream.resource(
+    fn ->
+      ref = make_ref()
+      {:ok, _subscription} = MyApp.Source.subscribe(source, self(), ref)
+      ref
+    end,
+    fn ref ->
+      receive do
+        {:chunk, ^ref, chunk} -> {[chunk], ref}
+        {:done, ^ref} -> {:halt, ref}
+        {:error, ^ref, reason} -> raise "source failed: #{inspect(reason)}"
+      end
+    end,
+    fn ref -> MyApp.Source.cancel(ref) end
+  )
+end
 ```
 
-## File streams
+Tag messages with a unique reference so late messages from an earlier
+subscription cannot be mixed in. The final callback runs when enumeration ends,
+fails, or the consumer halts early.
 
-`File.stream!/1` works without an adapter:
-
-```elixir
-rendered_chunks =
-  "README.md"
-  |> File.stream!()
-  |> MDEx.stream()
-  |> Enum.reduce(%{}, fn {id, document}, chunks ->
-    Map.put(chunks, id, MDEx.to_html!(document))
-  end)
-```
-
-The map keeps the latest rendered value for each id.
-
-You can also read fixed-size binary chunks:
-
-```elixir
-"large.md"
-|> File.stream!([], 2048)
-|> MDEx.stream()
-|> Enum.each(&consume/1)
-```
-
-A file or network chunk may split a UTF-8 code point. MDEx holds the incomplete
-bytes until the next chunk. Invalid UTF-8 raises when the Stream reaches those
-bytes. An incomplete code point at EOF also raises.
-
-## Req response streams
-
-Req's asynchronous response body is an Enumerable, so it can feed MDEx
-directly:
-
-```elixir
-Req.get!(url, into: :self).body
-|> MDEx.stream(extension: [table: true])
-|> Enum.each(&consume/1)
-```
-
-The body does not need to be joined first. Req cancels the asynchronous request
-if the consumer stops early.
-
-## Partial Markdown
-
-MDEx uses its fragment parser on the cumulative source. This keeps partial
-output valid while more source is expected:
-
-```elixir
-["**Fol", "low**"]
-|> MDEx.stream()
-|> Enum.each(fn {_id, document} ->
-  IO.inspect(MDEx.to_html!(document))
-end)
-```
-
-The first update renders a closed `<strong>` element. The next update uses the
-same id and replaces it. At EOF, MDEx parses the source without temporary
-closing syntax and emits another replacement only when that changes the AST.
+`Stream.resource/3` does not make the producer demand-driven. If it outruns the
+consumer, messages accumulate in the receiving process. Use the source's own
+acknowledgement or pause mechanism when it has one, otherwise bound the buffer
+yourself. Subscription, buffering, timeouts, and cancellation belong to the
+source, which is why MDEx consumes a binary Stream rather than offering its own
+push API.
 
 ## Phoenix LiveView
 
-The MDEx id can be the id for a
-[`Phoenix.LiveView.stream/4`](https://phoenix-live-view.hexdocs.pm/Phoenix.LiveView.html#stream/4)
-entry.
-
-Configure the id before you create the LiveView stream:
+An MDEx id can be the id of a `Phoenix.LiveView.stream/4` entry. Configure the
+`dom_id` before creating the LiveView stream:
 
 ```elixir
 def mount(_params, _session, socket) do
   {:ok,
    socket
-   |> stream_configure(:markdown, dom_id: fn {id, _document} ->
-     "markdown-#{id}"
-   end)
+   |> stream_configure(:markdown, dom_id: fn {id, _document} -> "markdown-#{id}" end)
    |> stream(:markdown, [])}
 end
 ```
 
-Use the exact DOM id that LiveView gives to the template:
-
 ```heex
 <div id="markdown" class="markdown-body" phx-update="stream">
-  <div
-    :for={{dom_id, {_id, document}} <- @streams.markdown}
-    id={dom_id}
-    class="contents"
-  >
+  <div :for={{dom_id, {_id, document}} <- @streams.markdown} id={dom_id} class="contents">
     {Phoenix.HTML.raw(MDEx.to_html!(document))}
   </div>
 </div>
 ```
 
-Use `Phoenix.HTML.raw/1` only after applying the MDEx safety options required by
-your application.
+Use `Phoenix.HTML.raw/1` only after applying the safety options your application
+needs.
 
-### Read the source outside the LiveView callback
-
-`Phoenix.LiveView.stream/4` reads its Enumerable in the LiveView process. Do
-not pass it an LLM, socket, or other long-running source:
-
-```elixir
-# This blocks the LiveView callback until the source ends.
-stream(socket, :markdown, MDEx.stream(long_running_chunks))
-```
-
-Read the MDEx Stream in a task and send each finite chunk to the LiveView:
+`Phoenix.LiveView.stream/4` reads its Enumerable inside the LiveView process, so
+never hand it a long-running source. Read it in a task and forward each chunk:
 
 ```elixir
 def start_markdown(socket, chunks) do
@@ -263,168 +194,51 @@ end
 def handle_info({:markdown_chunk, chunk}, socket) do
   {:noreply, stream_insert(socket, :markdown, chunk)}
 end
-
-def handle_async(:markdown_producer, {:ok, :ok}, socket) do
-  {:noreply, socket}
-end
 ```
 
-You may also send a finite list and call `stream/4` once per batch:
+A repeated id updates the same DOM child in place without moving it, including
+when a lower id repeats after a higher one was inserted. LiveView drops streamed
+data from socket state after each render, so the source and MDEx state must stay
+in the producer. `stream_async/4` does not forward chunks while its task runs.
 
-```elixir
-def handle_info({:markdown_chunks, chunks}, socket) do
-  {:noreply, stream(socket, :markdown, chunks)}
-end
-```
-
-When an id repeats, LiveView updates the same DOM child without moving it. This
-also works when a lower id repeats after a higher id was inserted. LiveView
-drops streamed data from socket state after each render, so the source and
-MDEx state must stay in the producer.
-
-`stream_async/4` does not forward chunks while its task runs. It waits for the
-task result and then passes that result to `stream/4`.
-
-### Start a new response
-
-MDEx ids start at `0` for each Stream run. Reset the LiveView stream when the UI
-shows one active response:
+Ids restart at `0` for each Stream run, so reset the LiveView stream when a new
+response begins:
 
 ```elixir
 socket = stream(socket, :markdown, [], reset: true)
 ```
 
-For several active responses, include a response id in each DOM id. An MDEx id
-is unique only within one Stream run.
+For several concurrent responses, include a response id in each DOM id.
 
-## Runnable Phoenix example
+## Runnable example
 
 [`examples/streaming.exs`](https://github.com/leandrocp/mdex/blob/main/examples/streaming.exs)
-runs this path:
-
-```text
-Req.Response.Async Enumerable
-  -> MDEx.stream/2
-  -> one {id, document} chunk per message
-  -> Phoenix.LiveView.stream_insert/4
-  -> phx-update="stream"
-```
-
-Run it from the repository:
+runs `Req` → `MDEx.stream/2` → `stream_insert/4` → `phx-update="stream"` with
+Lumis highlighting, an adjustable delay, and live metrics:
 
 ```shell
 elixir examples/streaming.exs
 ```
 
-The URL defaults to the raw MDEx README on GitHub. The example splits large
-network reads into 64-byte chunks so updates stay visible. The controls include
-pause and resume at a source chunk boundary, a delay of up to 1000 ms, and
-optional auto-scroll. New keyed preview chunks use a short reveal animation
-unless the browser requests reduced motion. Stream, pause, resume, stop, and
-the delay slider stay in the sticky diagnostics panel while the page scrolls.
-
-The example enables `render: [unsafe: true]` so raw HTML in the README is
-visible. Use trusted URLs when reusing this setting. Lumis highlights partial
-code fences. The page also shows source counts, MDEx updates, DOM chunks, and
-current and peak memory for the producer and LiveView processes. A sticky
-diagnostics panel beside the preview keeps this run data and the latest chunk
-indexes visible while the page scrolls. The compact monospace activity uses
-`+id` for inserts and `~id` for replacements.
-
-## Adapting message-based sources
-
-Prefer an `Enumerable` from the source when one is available. It composes with
-`MDEx.stream/2` directly and may preserve upstream demand and cancellation.
-
-Some sources only deliver chunks through process messages or callbacks. Adapt
-those sources to an Elixir Stream at the application boundary with
-`Stream.resource/3`:
-
-```elixir
-# This adapter belongs to the application, not MDEx.
-defmodule MyApp.MarkdownMessageStream do
-  def new(source) do
-    Stream.resource(
-      fn ->
-        ref = make_ref()
-
-        {:ok, subscription} =
-          MyApp.MarkdownSource.subscribe(source, self(), ref)
-
-        {ref, subscription}
-      end,
-      fn {ref, _subscription} = state ->
-        receive do
-          {:markdown_chunk, ^ref, chunk} when is_binary(chunk) ->
-            {[chunk], state}
-
-          {:markdown_done, ^ref} ->
-            {:halt, state}
-
-          {:markdown_error, ^ref, reason} ->
-            raise "Markdown source failed: #{inspect(reason)}"
-        end
-      end,
-      fn {_ref, subscription} ->
-        MyApp.MarkdownSource.cancel(subscription)
-      end
-    )
-  end
-end
-```
-
-Replace `MyApp.MarkdownSource` and the message shapes with the API provided by
-the source. The resulting value is a normal Stream:
-
-```elixir
-source
-|> MyApp.MarkdownMessageStream.new()
-|> MDEx.stream()
-|> Enum.each(&consume/1)
-```
-
-`Stream.resource/3` gives the adapter a clear lifecycle:
-
-1. Subscribe lazily in the first callback. `self()` is the process that
-   enumerates the Stream.
-2. Receive one binary chunk at a time in the second callback.
-3. Return `{:halt, state}` when the source reports EOF.
-4. Raise when the source reports an error.
-5. Cancel or unsubscribe in the final callback. It runs when enumeration ends,
-   fails, or the downstream consumer halts early.
-
-Tag messages with a unique reference so concurrent streams and late messages
-from an earlier subscription cannot be mixed. The adapter also owns any
-timeout and source-specific cleanup policy.
-
-### Backpressure
-
-`Stream.resource/3` makes a message source look like an Enumerable, but it does
-not make the producer demand-driven. If the producer sends chunks faster than
-the Stream consumes them, messages accumulate in the receiving process.
-
-For an unbounded or high-volume source, use its acknowledgement, pause, or
-demand mechanism when available. Otherwise the application must define a
-bounded buffer or an overflow policy. If the source already provides an
-Enumerable with cancellation or demand, use that instead of a message adapter.
-
-Subscription, buffering, timeouts, and cancellation are source concerns. MDEx
-therefore does not add a separate `new/push/finish` API; it consumes the binary
-Stream produced by the adapter.
+It enables `render: [unsafe: true]` so raw HTML in the fetched README is visible.
+Use trusted URLs when reusing that setting.
 
 ## Options
 
-Pass normal MDEx options as the second argument:
+`MDEx.stream/2` takes the same options as the other render functions:
 
 ```elixir
 chunks
 |> MDEx.stream(
   extension: [strikethrough: true, table: true, tasklist: true],
-  render: [unsafe: false],
-  syntax_highlight: [
-    engine: :lumis,
-    opts: [formatter: {:html_inline, theme: "github_light"}]
-  ]
+  syntax_highlight: [engine: :lumis, opts: [formatter: {:html_inline, theme: "github_light"}]],
+  auto_close: false
 )
 |> Enum.each(&consume/1)
 ```
+
+Plugins attach once when enumeration starts, and their steps run on every
+emitted document, including repeated ids. Their parser options apply before
+parsing, but their steps only ever see one keyed chunk. A plugin that
+preprocesses `document.buffer` does not fit `MDEx.stream/2` — collect the full
+source and use the one-document API instead.

--- a/lib/mdex.ex
+++ b/lib/mdex.ex
@@ -660,10 +660,11 @@ defmodule MDEx do
   def to_xml(markdown, options) when is_binary(markdown) and is_list(options) do
     {document, options} = Keyword.pop(options, :document, nil)
     markdown = document || markdown
-    options = Document.put_options(MDEx.new(), options).options
+    document = Document.put_options(MDEx.new(), options)
 
     markdown
-    |> Comrak.markdown_to_xml(Document.rust_options!(options))
+    |> maybe_auto_close(document)
+    |> Comrak.markdown_to_xml(Document.rust_options!(document.options))
     |> maybe_trim()
   end
 
@@ -679,6 +680,14 @@ defmodule MDEx do
       to_xml(%Document{nodes: List.wrap(source)}, options)
     else
       {:error, %InvalidInputError{found: source}}
+    end
+  end
+
+  defp maybe_auto_close(markdown, document) do
+    if Document.get_private(document, :auto_close, false) do
+      MDEx.FragmentParser.complete(markdown)
+    else
+      markdown
     end
   end
 
@@ -1439,7 +1448,7 @@ defmodule MDEx do
 
   > #### Experimental {: .warning}
   >
-  > This function may change before its first stable release.
+  > Consider this function experimental and subject to change.
 
   """
   @spec stream(Enumerable.t(), Document.options()) :: Enumerable.t()

--- a/lib/mdex.ex
+++ b/lib/mdex.ex
@@ -1300,9 +1300,9 @@ defmodule MDEx do
     - `:syntax_highlight` (`t:MDEx.Document.syntax_highlight_options/0` | `nil`) - Syntax highlight options, or `nil` to turn it off.
     - `:sanitize` (`t:sanitize_options/0` | `nil`) - HTML cleaning options, or `nil` to turn it off. Defaults to `nil`.
     - `:assigns` (`t:map/0`) - Values for pipelines, plugins, and HEEx. Defaults to `%{}`.
+    - `:auto_close` (`t:boolean/0`) - Closes Markdown syntax left open at the end of the source. Defaults to `false`, and to `true` in `MDEx.stream/2`.
 
-  The `:streaming` option is deprecated. Pass an Enumerable of Markdown chunks
-  to `MDEx.stream/2`.
+  The `:streaming` option is deprecated. Use `:auto_close`.
 
   `:sanitize` and `:unsafe` are off by default. See the
   [Safety guide](https://hexdocs.pm/mdex/safety.html).
@@ -1352,7 +1352,7 @@ defmodule MDEx do
   @spec new(keyword()) :: Document.t()
   def new(options \\ []) do
     if Keyword.has_key?(options, :streaming) do
-      IO.warn("the :streaming option is deprecated; pass an Enumerable of Markdown chunks to MDEx.stream/2")
+      IO.warn("the :streaming option is deprecated; use :auto_close instead")
     end
 
     # TODO: remove :document in v1.0
@@ -1427,6 +1427,13 @@ defmodule MDEx do
         cache({id, :html}, MDEx.to_html!(document))
       end)
 
+  Markdown syntax left open at the end of a chunk is closed so partial output
+  stays readable, which is why the first document above renders `<h1>Hel</h1>`
+  rather than `# Hel`. Pass `auto_close: false` to render the source as written:
+
+      iex> ["a [x](htt"] |> MDEx.stream(auto_close: false) |> Enum.map(fn {id, doc} -> {id, MDEx.to_html!(doc)} end)
+      [{0, "<p>a [x](htt</p>"}]
+
   See the [Streaming guide](streaming.html) for the id rules, Req, and Phoenix
   LiveView.
 
@@ -1440,6 +1447,8 @@ defmodule MDEx do
     chunks
     |> Stream.transform(
       fn ->
+        {auto_close, options} = Keyword.pop(options, :auto_close, true)
+
         document =
           options
           |> Keyword.drop([:document, :markdown, :streaming])
@@ -1447,6 +1456,7 @@ defmodule MDEx do
 
         %{
           document: document,
+          auto_close: auto_close,
           rust_options: Document.rust_options!(document.options),
           source: "",
           utf8_suffix: "",
@@ -1499,7 +1509,7 @@ defmodule MDEx do
   defp emit_stream_source(source, state) do
     nodes =
       source
-      |> MDEx.FragmentParser.complete(preserve_pending_html: true)
+      |> stream_auto_close(state)
       |> stream_parse_nodes!(state.rust_options)
 
     state = state |> Map.put(:source, source) |> stream_maybe_finalize_open(nodes)
@@ -1508,6 +1518,12 @@ defmodule MDEx do
     events = stream_document_events(changed_ids, segment_nodes, state.document)
 
     {events, %{state | segment_nodes: segment_nodes}}
+  end
+
+  defp stream_auto_close(source, %{auto_close: false}), do: source
+
+  defp stream_auto_close(source, _state) do
+    MDEx.FragmentParser.complete(source, preserve_pending_html: true)
   end
 
   defp stream_parse_nodes!(source, rust_options) do

--- a/lib/mdex/document.ex
+++ b/lib/mdex/document.ex
@@ -678,6 +678,7 @@ defmodule MDEx.Document do
     :render,
     :syntax_highlight,
     :sanitize,
+    :auto_close,
     :streaming,
     :assigns,
     :plugins,
@@ -1632,10 +1633,15 @@ defmodule MDEx.Document do
       {:sanitize, options}, acc ->
         put_sanitize_options(acc, options)
 
+      {:auto_close, value}, acc ->
+        acc
+        |> Map.update!(:options, &Keyword.put(&1 || [], :auto_close, value))
+        |> Document.put_private(:auto_close, value)
+
       {:streaming, value}, acc ->
         acc
-        |> Map.update!(:options, &Keyword.put(&1 || [], :streaming, value))
-        |> Document.put_private(:fragment_completion, value)
+        |> Map.update!(:options, &Keyword.put(&1 || [], :auto_close, value))
+        |> Document.put_private(:auto_close, value)
 
       {:assigns, value}, acc ->
         %{acc | options: Keyword.put(acc.options || [], :assigns, value)}
@@ -2145,7 +2151,7 @@ defmodule MDEx.Document do
   1. Processes buffered markdown: If there are any markdown chunks in the buffer (added via `put_markdown/3` for example),
      they are parsed and added to the document. If the document already has nodes, they are combined with the buffer.
 
-  2. Closes partial syntax when called by `MDEx.stream/2`.
+  2. Closes Markdown syntax left open at the end of the buffer, when `:auto_close` is set.
 
   3. Executes pipeline steps: All registered steps (added via `append_steps/2` or `prepend_steps/2`) are
      executed in order. Steps can transform the document or halt the pipeline.
@@ -2245,7 +2251,7 @@ defmodule MDEx.Document do
 
   defp flush_buffer(document, buffer) do
     {buffer, document} =
-      if Document.get_private(document, :fragment_completion, false) do
+      if Document.get_private(document, :auto_close, false) do
         state = Document.get_private(document, :fragment_state)
         {completed, new_state} = MDEx.FragmentParser.complete_with_state(buffer, state)
         {completed, Document.put_private(document, :fragment_state, new_state)}
@@ -2362,6 +2368,24 @@ defmodule MDEx.Document do
 
   @doc """
   Adds Markdown to the document buffer.
+
+  Use this to compose a document from separate pieces of Markdown. Any AST edit
+  made by a pipeline step or by inserting nodes is kept when more Markdown is
+  added later.
+
+  > #### Not for streaming {: .warning}
+  >
+  > Keeping those AST edits means `run/1` renders the current AST back to
+  > Markdown before parsing the buffer with it, so each call costs a full render
+  > plus a full parse of everything added so far.
+  >
+  > That round trip also loses what the AST does not store: blank lines between
+  > blocks, whether a list is loose or tight, and a table's delimiter row. Adding
+  > one chunk at a time therefore changes the output — two paragraphs merge into
+  > one, a loose list turns tight, and a table's `|---|` row becomes a data row.
+  >
+  > For Markdown arriving in chunks use `MDEx.stream/2`, which keeps the source
+  > text instead of the AST.
 
   ## Examples
 

--- a/test/mdex/document_test.exs
+++ b/test/mdex/document_test.exs
@@ -1705,21 +1705,56 @@ defmodule MDEx.DocumentTest do
 
     assert MapSet.equal?(
              opts,
-             MapSet.new([:extension, :parse, :render, :sanitize, :streaming, :syntax_highlight, :assigns, :plugins, :codefence_renderers])
+             MapSet.new([
+               :extension,
+               :parse,
+               :render,
+               :sanitize,
+               :auto_close,
+               :streaming,
+               :syntax_highlight,
+               :assigns,
+               :plugins,
+               :codefence_renderers
+             ])
            )
 
     assert %{registered_options: opts} = Document.register_options(%MDEx.Document{}, [:foo])
 
     assert MapSet.equal?(
              opts,
-             MapSet.new([:extension, :parse, :render, :sanitize, :streaming, :syntax_highlight, :assigns, :plugins, :codefence_renderers, :foo])
+             MapSet.new([
+               :extension,
+               :parse,
+               :render,
+               :sanitize,
+               :auto_close,
+               :streaming,
+               :syntax_highlight,
+               :assigns,
+               :plugins,
+               :codefence_renderers,
+               :foo
+             ])
            )
 
     assert %{registered_options: opts} = Document.register_options(%MDEx.Document{}, [:foo, :foo])
 
     assert MapSet.equal?(
              opts,
-             MapSet.new([:extension, :parse, :render, :sanitize, :streaming, :syntax_highlight, :assigns, :plugins, :codefence_renderers, :foo])
+             MapSet.new([
+               :extension,
+               :parse,
+               :render,
+               :sanitize,
+               :auto_close,
+               :streaming,
+               :syntax_highlight,
+               :assigns,
+               :plugins,
+               :codefence_renderers,
+               :foo
+             ])
            )
   end
 

--- a/test/mdex/stream_test.exs
+++ b/test/mdex/stream_test.exs
@@ -24,8 +24,8 @@ defmodule MDEx.StreamTest do
 
   defp streaming_document(options \\ []) do
     options
+    |> Keyword.put(:auto_close, true)
     |> MDEx.new()
-    |> MDEx.Document.put_private(:fragment_completion, true)
   end
 
   defp nodes(chunks, document \\ streaming_document()) do
@@ -1295,7 +1295,22 @@ defmodule MDEx.StreamTest do
       end)
 
     assert warning =~ "the :streaming option is deprecated"
-    assert warning =~ "MDEx.stream/2"
+    assert warning =~ ":auto_close"
+  end
+
+  test "auto_close is on by default and can be turned off" do
+    assert [{0, ~s(<p>a <a href="htt">x</a></p>)}, {0, "<p>a [x](htt</p>"}] =
+             ["a [x](htt"] |> MDEx.stream() |> Enum.map(fn {id, doc} -> {id, MDEx.to_html!(doc)} end)
+
+    assert [{0, "<p>a [x](htt</p>"}] =
+             ["a [x](htt"]
+             |> MDEx.stream(auto_close: false)
+             |> Enum.map(fn {id, doc} -> {id, MDEx.to_html!(doc)} end)
+  end
+
+  test "auto_close is off by default outside streaming" do
+    assert MDEx.to_html!("a [x](htt") == "<p>a [x](htt</p>"
+    assert MDEx.to_html!("a [x](htt", auto_close: true) == ~s(<p>a <a href="htt">x</a></p>)
   end
 
   test "returns a native lazy Stream" do

--- a/test/mdex/stream_test.exs
+++ b/test/mdex/stream_test.exs
@@ -1765,4 +1765,126 @@ defmodule MDEx.StreamTest do
         send(caller, {:parser_calls, Enum.reverse(calls)})
     end
   end
+
+  describe "streaming a source matches rendering it in one shot" do
+    @comparison_options [
+      extension: [table: true, strikethrough: true, tasklist: true, footnotes: true, autolink: true],
+      render: [unsafe: true]
+    ]
+
+    @sources [
+      heading_and_paragraphs: "# Title\n\nFirst paragraph.\n\nSecond paragraph.\n",
+      tight_list: "- one\n- two\n- three\n",
+      loose_list: "- one\n\n- two\n\n- three\n",
+      nested_list: "- one\n  - nested\n  - also\n- two\n",
+      task_list: "- [ ] todo\n- [x] done\n",
+      fenced_code: "Intro:\n\n```elixir\ndef a(b), do: b\n```\n\nOutro.\n",
+      table: "| name | qty |\n|---|---|\n| apples | 3 |\n| pears | 7 |\n",
+      block_quote: "> quoted\n> lines\n\nAfter.\n",
+      raw_html: "<div class=\"x\">\n  <p>raw</p>\n</div>\n\nAfter.\n",
+      reference_link: "See [docs][1] and [more][2].\n\n[1]: https://a.test\n[2]: https://b.test\n",
+      footnote: "Text with a note[^1].\n\n[^1]: The note.\n",
+      inline_marks: "A **bold**, *em*, ~~struck~~, `code`, and [link](https://a.test).\n",
+      image: "![alt](https://a.test/i.png)\n\nAfter.\n",
+      thematic_break: "Before.\n\n---\n\nAfter.\n",
+      setext_heading: "Title\n=====\n\nBody.\n",
+      mixed: """
+      # Report
+
+      Summary paragraph with **bold** and a [link](https://a.test).
+
+      - first
+      - second
+
+      ```elixir
+      IO.puts(:ok)
+      ```
+
+      | col | val |
+      |---|---|
+      | a | 1 |
+
+      > closing note
+      """
+    ]
+
+    # A chunk boundary can fall anywhere, so exercise sizes that split inside
+    # markers, across lines, and across whole blocks.
+    @chunk_sizes [1, 2, 3, 5, 7, 13, 64]
+
+    defp chunk_every(source, size) do
+      source |> :binary.bin_to_list() |> Enum.chunk_every(size) |> Enum.map(&:binary.list_to_bin/1)
+    end
+
+    defp latest_per_id(source, size, options) do
+      source
+      |> chunk_every(size)
+      |> MDEx.stream(options)
+      |> Enum.reduce(%{}, fn {id, document}, acc -> Map.put(acc, id, document) end)
+      |> Enum.sort_by(&elem(&1, 0))
+      |> Enum.map(&elem(&1, 1))
+    end
+
+    defp squeeze(html), do: String.replace(html, ~r/\s+/, "")
+
+    test "the final keyed chunks render the same HTML as to_html!/2" do
+      for {name, source} <- @sources, size <- @chunk_sizes do
+        expected = MDEx.to_html!(source, @comparison_options)
+
+        streamed =
+          source
+          |> latest_per_id(size, @comparison_options)
+          |> Enum.map_join("\n", &MDEx.to_html!/1)
+
+        assert squeeze(streamed) == squeeze(expected),
+               "#{name} at chunk size #{size}\nstreamed: #{inspect(streamed)}\nexpected: #{inspect(expected)}"
+      end
+    end
+
+    test "every top-level node of the one-shot parse lands in exactly one keyed chunk" do
+      for {name, source} <- @sources, size <- @chunk_sizes do
+        expected = MDEx.parse_document!(source, @comparison_options).nodes
+        streamed = source |> latest_per_id(size, @comparison_options) |> Enum.flat_map(& &1.nodes)
+
+        assert streamed == expected,
+               "#{name} at chunk size #{size}: keyed chunks do not partition the document"
+      end
+    end
+
+    test "a single chunk holding the whole source matches to_html!/2" do
+      for {name, source} <- @sources do
+        streamed =
+          [source]
+          |> MDEx.stream(@comparison_options)
+          |> Enum.reduce(%{}, fn {id, document}, acc -> Map.put(acc, id, MDEx.to_html!(document)) end)
+          |> Enum.sort_by(&elem(&1, 0))
+          |> Enum.map_join("\n", &elem(&1, 1))
+
+        assert squeeze(streamed) == squeeze(MDEx.to_html!(source, @comparison_options)),
+               to_string(name)
+      end
+    end
+
+    test "auto_close: false also converges on the one-shot render" do
+      options = Keyword.put(@comparison_options, :auto_close, false)
+
+      for {name, source} <- @sources, size <- [1, 7, 64] do
+        streamed =
+          source
+          |> latest_per_id(size, options)
+          |> Enum.map_join("\n", &MDEx.to_html!/1)
+
+        assert squeeze(streamed) == squeeze(MDEx.to_html!(source, options)),
+               "#{name} at chunk size #{size} with auto_close: false"
+      end
+    end
+
+    test "no keyed chunk ever renders temporary closing syntax at the end of input" do
+      for {_name, source} <- @sources, size <- @chunk_sizes do
+        html = source |> latest_per_id(size, @comparison_options) |> Enum.map_join(&MDEx.to_html!/1)
+
+        refute html =~ "mdex:incomplete-link"
+      end
+    end
+  end
 end

--- a/test/mdex/stream_test.exs
+++ b/test/mdex/stream_test.exs
@@ -1313,6 +1313,22 @@ defmodule MDEx.StreamTest do
     assert MDEx.to_html!("a [x](htt", auto_close: true) == ~s(<p>a <a href="htt">x</a></p>)
   end
 
+  test "auto_close applies to every renderer that accepts Markdown" do
+    source = "a [x](htt"
+
+    assert MDEx.to_html!(source, auto_close: true) =~ ~s(<a href="htt">)
+    assert MDEx.to_json!(source, auto_close: true) =~ "MDEx.Link"
+    assert [_, %{"attributes" => %{"link" => "htt"}} | _] = MDEx.to_delta!(source, auto_close: true)
+    assert [%MDEx.Paragraph{nodes: [_, %MDEx.Link{url: "htt"}]}] = MDEx.parse_document!(source, auto_close: true).nodes
+
+    # to_xml/2 renders a binary natively instead of running the document
+    # pipeline, so it needs the source completed before the native call.
+    xml = MDEx.to_xml!(source, auto_close: true)
+    assert xml =~ "<link"
+    assert xml == MDEx.new(markdown: source, auto_close: true) |> MDEx.to_xml!()
+    refute MDEx.to_xml!(source) =~ "<link"
+  end
+
   test "returns a native lazy Stream" do
     parent = self()
 

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -435,9 +435,26 @@ Use `MDEx.stream/2` for LLM, SSE, file, or HTTP response chunks.
 end)
 ```
 
-`MDEx.new(streaming: true)` is deprecated. Use `MDEx.new/1` and
-`MDEx.Document.put_markdown/3` to build one document in steps. Do not use them
-as a manual streaming API.
+### Partial Markdown
+
+`:auto_close` closes Markdown syntax left open at the end of the source, so
+`Some **bo` renders as bold rather than literal asterisks. It works on every
+render function, defaults to `false`, and defaults to `true` in `MDEx.stream/2`.
+
+```elixir
+MDEx.to_html!(source, auto_close: true)
+chunks |> MDEx.stream(auto_close: false)
+```
+
+Use it when you hold the whole response as a string and only need it to render
+sensibly while it grows. Use `MDEx.stream/2` when you have the chunks and want
+keyed output.
+
+`MDEx.new(streaming: true)` is deprecated. Use `:auto_close`.
+`MDEx.Document.put_markdown/3` is for composing a document from separate pieces
+of Markdown, not for feeding chunks — it renders the AST back to Markdown on
+every call, which is slower and loses blank lines, list looseness, and table
+delimiter rows.
 
 ## Output Formats
 
@@ -599,9 +616,10 @@ doc = MDEx.Document.wrap(%MDEx.Text{literal: "Hello"})
 5. **Forgetting required extensions** - Tables, strikethrough, math, footnotes, and similar syntax need explicit options unless a plugin enables them.
 6. **Treating `parse_fragment!/1` like a full document parser** - It is for one fragment node.
 7. **Expecting component imports to be automatic in HEEx** - Import or fully qualify them yourself.
-8. **Using `MDEx.new(streaming: true)`** - It is deprecated; pass chunks to `MDEx.stream/2`.
+8. **Using `MDEx.new(streaming: true)`** - It is deprecated; use `auto_close: true`.
 9. **Putting inline nodes at the root** - Wrap them in a block container.
 10. **Using plugins without attaching or passing them** - They do nothing until attached.
+11. **Feeding stream chunks to `MDEx.Document.put_markdown/3`** - It composes documents; use `MDEx.stream/2` for chunks.
 
 ## Recommended Patterns
 


### PR DESCRIPTION
Renames the deprecated `:streaming` option to `:auto_close` and makes it a first-class option on every render path, instead of something only reachable through a deprecated document flag.

## What `:auto_close` does

Closes Markdown left open at the end of the source — emphasis, inline code, fenced blocks, links, images, tables, list markers, HTML tags — so partial output stays readable.

```elixir
MDEx.to_html!("Some **bo")                     #=> "<p>Some **bo</p>"
MDEx.to_html!("Some **bo", auto_close: true)   #=> "<p>Some <strong>bo</strong></p>"
```

Defaults to `false`, and to `true` in `MDEx.stream/2`, which preserves current behaviour.

## Why

`MDEx.stream/2` always completed fragments with no way to opt out. That is not always what a caller wants — a link whose URL is still arriving renders as a real, clickable link:

```elixir
MDEx.to_html!("a [x](htt", auto_close: true)   #=> ~s(<p>a <a href="htt">x</a></p>)
```

`auto_close: false` now renders the source as written, in one-shot renders and inside `MDEx.stream/2`.

The capability also had no home outside streaming. Rendering a source that may end mid-token is a pure function on a binary and is useful on its own, so callers holding a whole growing response as a string no longer need `MDEx.stream/2` or a deprecated flag.

`:streaming` still works and warns, now pointing at `:auto_close`.

## Docs

- `Document.put_markdown/3` gains a warning that it composes a document from separate pieces of Markdown and is not for feeding stream chunks. `run/1` renders the current AST back to Markdown before parsing the buffer with it, so each call costs a full render plus a full parse, and the round trip loses what the AST does not store — blank lines between blocks, list looseness, and a table's delimiter row. Feeding chunks that way merges paragraphs, turns loose lists tight, and turns a table's `|---|` row into a data row.
- The streaming guide is split into the two independent concepts and cut from 430 to 244 lines.
- `MDEx.new/1` documents `:auto_close`; `usage-rules.md` updated.

## Tests

828 passing (63 doctests, 765 tests), up from 825. New tests cover the default in and out of streaming, and turning it off. `mix format --check-formatted`, `mix compile --warnings-as-errors`, and `mix credo --strict` are clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `auto_close` option to control whether incomplete Markdown syntax is closed at chunk boundaries.
  * Streaming output closes incomplete syntax by default; this can be disabled with `auto_close: false`.
  * Outside streaming, automatic closure remains disabled unless explicitly enabled.

* **Documentation**
  * Updated streaming guides and usage guidance with the new option, behavior, examples, and recommended usage patterns.
  * Clarified the distinction between composing Markdown documents and processing chunked input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->