### PR TITLE
perf: skip AST struct conversion when rendering Markdown

### DIFF
--- a/lib/mdex.ex
+++ b/lib/mdex.ex
@@ -1180,8 +1180,7 @@ defmodule MDEx do
     end
   end
 
-  # Markdown that no step or renderer will touch renders without an AST, skipping both
-  # struct translation passes. `:commonmark` is out: the NIF only renders it from a document.
+  # `:commonmark` is excluded: the NIF only renders it from a document.
   defp source_markdown(document, format) when format in [:html, :xml] do
     if document.options[:codefence_renderers] in [nil, %{}] do
       Document.unparsed_markdown(document)

--- a/lib/mdex.ex
+++ b/lib/mdex.ex
@@ -1180,9 +1180,8 @@ defmodule MDEx do
     end
   end
 
-  # Markdown that no step or renderer will touch doesn't need an Elixir AST, and
-  # skipping it also skips both struct translation passes. `:commonmark` always needs
-  # one because the NIF only renders it from a document.
+  # Markdown that no step or renderer will touch renders without an AST, skipping both
+  # struct translation passes. `:commonmark` is out: the NIF only renders it from a document.
   defp source_markdown(document, format) when format in [:html, :xml] do
     if document.options[:codefence_renderers] in [nil, %{}] do
       Document.unparsed_markdown(document)

--- a/lib/mdex.ex
+++ b/lib/mdex.ex
@@ -411,7 +411,7 @@ defmodule MDEx do
   end
 
   def to_html(%Document{} = document, options) when is_list(options) do
-    run_pipeline(document, options, :html)
+    run_pipeline(document, options, &Comrak.document_to_html/2, &Comrak.markdown_to_html/2)
   rescue
     ErlangError ->
       {:error, %DecodeError{document: document}}
@@ -669,7 +669,7 @@ defmodule MDEx do
   end
 
   def to_xml(%Document{} = document, options) when is_list(options) do
-    run_pipeline(document, options, :xml)
+    run_pipeline(document, options, &Comrak.document_to_xml/2)
   rescue
     ErlangError ->
       {:error, %DecodeError{document: document}}
@@ -1044,7 +1044,7 @@ defmodule MDEx do
   """
   @spec to_markdown(Document.t(), MDEx.Document.options()) :: {:ok, String.t()} | {:error, MDEx.DecodeError.t()}
   def to_markdown(%Document{} = document, options \\ []) do
-    run_pipeline(document, options, :commonmark)
+    run_pipeline(document, options, &Comrak.document_to_commonmark/2)
   end
 
   @doc """
@@ -1155,7 +1155,7 @@ defmodule MDEx do
   defp maybe_trim(result) when is_binary(result), do: {:ok, String.trim(result)}
   defp maybe_trim(error), do: error
 
-  defp run_pipeline(document, options, format) do
+  defp run_pipeline(document, options, converter, markdown_converter \\ nil) do
     {document_opt, options} = pop_deprecated_document_option(options)
 
     document =
@@ -1163,40 +1163,34 @@ defmodule MDEx do
       |> Document.put_options(options)
       |> maybe_apply_document_option(document_opt)
 
-    case source_markdown(document, format) do
+    case source_markdown(document, markdown_converter) do
       {:ok, markdown} ->
         markdown
-        |> render_markdown(format, Document.rust_options!(document.options))
+        |> markdown_converter.(Document.rust_options!(document.options))
         |> maybe_trim()
 
       :error ->
-        document = Document.run(document)
-
         document
-        |> apply_codefence_renderers_to_document(document.options[:codefence_renderers])
-        |> ComrakConverter.from_mdex()
-        |> render_document(format, Document.rust_options!(document.options))
-        |> maybe_trim()
+        |> Document.run()
+        |> then(fn document ->
+          document
+          |> apply_codefence_renderers_to_document(document.options[:codefence_renderers])
+          |> ComrakConverter.from_mdex()
+          |> converter.(Document.rust_options!(document.options))
+          |> maybe_trim()
+        end)
     end
   end
 
-  # `:commonmark` is excluded: the NIF only renders it from a document.
-  defp source_markdown(document, format) when format in [:html, :xml] do
+  defp source_markdown(_document, nil), do: :error
+
+  defp source_markdown(document, _markdown_converter) do
     if document.options[:codefence_renderers] in [nil, %{}] do
       Document.unparsed_markdown(document)
     else
       :error
     end
   end
-
-  defp source_markdown(_document, _format), do: :error
-
-  defp render_markdown(markdown, :html, options), do: Comrak.markdown_to_html(markdown, options)
-  defp render_markdown(markdown, :xml, options), do: Comrak.markdown_to_xml(markdown, options)
-
-  defp render_document(document, :html, options), do: Comrak.document_to_html(document, options)
-  defp render_document(document, :xml, options), do: Comrak.document_to_xml(document, options)
-  defp render_document(document, :commonmark, options), do: Comrak.document_to_commonmark(document, options)
 
   defp apply_codefence_renderers_to_document(document, renderers) when renderers in [nil, %{}] do
     document

--- a/lib/mdex.ex
+++ b/lib/mdex.ex
@@ -411,7 +411,7 @@ defmodule MDEx do
   end
 
   def to_html(%Document{} = document, options) when is_list(options) do
-    run_pipeline(document, options, &Comrak.document_to_html/2)
+    run_pipeline(document, options, :html)
   rescue
     ErlangError ->
       {:error, %DecodeError{document: document}}
@@ -669,7 +669,7 @@ defmodule MDEx do
   end
 
   def to_xml(%Document{} = document, options) when is_list(options) do
-    run_pipeline(document, options, &Comrak.document_to_xml/2)
+    run_pipeline(document, options, :xml)
   rescue
     ErlangError ->
       {:error, %DecodeError{document: document}}
@@ -1044,7 +1044,7 @@ defmodule MDEx do
   """
   @spec to_markdown(Document.t(), MDEx.Document.options()) :: {:ok, String.t()} | {:error, MDEx.DecodeError.t()}
   def to_markdown(%Document{} = document, options \\ []) do
-    run_pipeline(document, options, &Comrak.document_to_commonmark/2)
+    run_pipeline(document, options, :commonmark)
   end
 
   @doc """
@@ -1155,21 +1155,50 @@ defmodule MDEx do
   defp maybe_trim(result) when is_binary(result), do: {:ok, String.trim(result)}
   defp maybe_trim(error), do: error
 
-  defp run_pipeline(document, options, converter) do
+  defp run_pipeline(document, options, format) do
     {document_opt, options} = pop_deprecated_document_option(options)
 
-    document
-    |> Document.put_options(options)
-    |> maybe_apply_document_option(document_opt)
-    |> Document.run()
-    |> then(fn document ->
+    document =
       document
-      |> apply_codefence_renderers_to_document(document.options[:codefence_renderers])
-      |> ComrakConverter.from_mdex()
-      |> converter.(Document.rust_options!(document.options))
-      |> maybe_trim()
-    end)
+      |> Document.put_options(options)
+      |> maybe_apply_document_option(document_opt)
+
+    case source_markdown(document, format) do
+      {:ok, markdown} ->
+        markdown
+        |> render_markdown(format, Document.rust_options!(document.options))
+        |> maybe_trim()
+
+      :error ->
+        document = Document.run(document)
+
+        document
+        |> apply_codefence_renderers_to_document(document.options[:codefence_renderers])
+        |> ComrakConverter.from_mdex()
+        |> render_document(format, Document.rust_options!(document.options))
+        |> maybe_trim()
+    end
   end
+
+  # Markdown that no step or renderer will touch doesn't need an Elixir AST, and
+  # skipping it also skips both struct translation passes. `:commonmark` always needs
+  # one because the NIF only renders it from a document.
+  defp source_markdown(document, format) when format in [:html, :xml] do
+    if document.options[:codefence_renderers] in [nil, %{}] do
+      Document.unparsed_markdown(document)
+    else
+      :error
+    end
+  end
+
+  defp source_markdown(_document, _format), do: :error
+
+  defp render_markdown(markdown, :html, options), do: Comrak.markdown_to_html(markdown, options)
+  defp render_markdown(markdown, :xml, options), do: Comrak.markdown_to_xml(markdown, options)
+
+  defp render_document(document, :html, options), do: Comrak.document_to_html(document, options)
+  defp render_document(document, :xml, options), do: Comrak.document_to_xml(document, options)
+  defp render_document(document, :commonmark, options), do: Comrak.document_to_commonmark(document, options)
 
   defp apply_codefence_renderers_to_document(document, renderers) when renderers in [nil, %{}] do
     document

--- a/lib/mdex/comrak_converter.ex
+++ b/lib/mdex/comrak_converter.ex
@@ -1,11 +1,8 @@
 defmodule MDEx.ComrakConverter do
   @moduledoc false
 
-  # Both namespaces declare the same fields, so a node converts by swapping
-  # `__struct__`. The table is compile-time: resolving it per node used to cost more
-  # than parsing and rendering combined.
-
-  # `Document` has its own clause because `MDEx.Document` also carries pipeline state.
+  # Both namespaces declare the same fields, so a node converts by swapping `__struct__`.
+  # `Document` is excluded: `MDEx.Document` also carries pipeline state.
   @nodes ~w(
     Alert Attributes BlockDirective BlockQuote Code CodeBlock DescriptionDetails
     DescriptionItem DescriptionList DescriptionTerm Emph Escaped EscapedTag
@@ -47,7 +44,7 @@ defmodule MDEx.ComrakConverter do
 
   defp convert(value, _direction), do: value
 
-  # A mismatched `mdex_native` may decode a different set of fields.
+  # Sizes differ when `mdex_native` decoded a different set of fields.
   defp rename(node, target, size) when map_size(node) == size, do: Map.replace!(node, :__struct__, target)
   defp rename(node, target, _size), do: struct(target, Map.from_struct(node))
 

--- a/lib/mdex/comrak_converter.ex
+++ b/lib/mdex/comrak_converter.ex
@@ -1,15 +1,11 @@
 defmodule MDEx.ComrakConverter do
   @moduledoc false
 
-  # `MDEx.Text` and `MDExNative.Comrak.Text` — and every other node struct — declare the
-  # same fields, so converting a node is a rename: swap `__struct__` and convert the
-  # fields that hold nested structs. Resolving the target module at runtime with
-  # `Module.split/1` + `Module.safe_concat/1` used to cost more than parsing and
-  # rendering combined, so the translation table is expanded into function clauses at
-  # compile time.
+  # Both namespaces declare the same fields, so a node converts by swapping
+  # `__struct__`. The table is compile-time: resolving it per node used to cost more
+  # than parsing and rendering combined.
 
-  # `Document` is excluded: `MDEx.Document` also carries pipeline state (`:options`,
-  # `:steps`, ...) that has no counterpart on the native side, so it gets its own clause.
+  # `Document` has its own clause because `MDEx.Document` also carries pipeline state.
   @nodes ~w(
     Alert Attributes BlockDirective BlockQuote Code CodeBlock DescriptionDetails
     DescriptionItem DescriptionList DescriptionTerm Emph Escaped EscapedTag
@@ -51,8 +47,7 @@ defmodule MDEx.ComrakConverter do
 
   defp convert(value, _direction), do: value
 
-  # A node decoded by a mismatched `mdex_native` may be missing fields this version
-  # knows about, so only swap `__struct__` when both structs are the same shape.
+  # A mismatched `mdex_native` may decode a different set of fields.
   defp rename(node, target, size) when map_size(node) == size, do: Map.replace!(node, :__struct__, target)
   defp rename(node, target, _size), do: struct(target, Map.from_struct(node))
 

--- a/lib/mdex/comrak_converter.ex
+++ b/lib/mdex/comrak_converter.ex
@@ -1,43 +1,77 @@
 defmodule MDEx.ComrakConverter do
   @moduledoc false
 
-  def to_mdex(value), do: convert(value, ["MDExNative", "Comrak"], MDEx)
-  def from_mdex(value), do: convert(value, ["MDEx"], MDExNative.Comrak)
+  # `MDEx.Text` and `MDExNative.Comrak.Text` — and every other node struct — declare the
+  # same fields, so converting a node is a rename: swap `__struct__` and convert the
+  # fields that hold nested structs. Resolving the target module at runtime with
+  # `Module.split/1` + `Module.safe_concat/1` used to cost more than parsing and
+  # rendering combined, so the translation table is expanded into function clauses at
+  # compile time.
 
-  defp convert(nodes, from, to) when is_list(nodes), do: Enum.map(nodes, &convert(&1, from, to))
+  # `Document` is excluded: `MDEx.Document` also carries pipeline state (`:options`,
+  # `:steps`, ...) that has no counterpart on the native side, so it gets its own clause.
+  @nodes ~w(
+    Alert Attributes BlockDirective BlockQuote Code CodeBlock DescriptionDetails
+    DescriptionItem DescriptionList DescriptionTerm Emph Escaped EscapedTag
+    FootnoteDefinition FootnoteReference FrontMatter Heading HeexBlock HeexInline
+    Highlight HtmlBlock HtmlInline Image Insert LineBreak Link List ListItem Math
+    MultilineBlockQuote Paragraph Raw ShortCode SoftBreak Sourcepos SpoileredText
+    Strikethrough Strong Subscript Subtext Superscript Table TableCell TableRow
+    TaskItem Text ThematicBreak Underline WikiLink
+  )a
 
-  defp convert(%module{} = node, from, to) do
-    case convert_module(module, from, to) do
-      {:ok, target} ->
-        fields =
-          node
-          |> Map.from_struct()
-          |> Map.new(fn
-            {key, value} when key in [:nodes, :sourcepos, :attrs] ->
-              {key, convert(value, from, to)}
+  def to_mdex(value), do: convert(value, :to_mdex)
+  def from_mdex(value), do: convert(value, :from_mdex)
 
-            {key, value} ->
-              {key, value}
-          end)
+  defp convert(nodes, direction) when is_list(nodes), do: Enum.map(nodes, &convert(&1, direction))
 
-        struct(target, fields)
+  defp convert(%MDExNative.Comrak.Document{} = document, :to_mdex = direction) do
+    %MDEx.Document{
+      nodes: convert(document.nodes, direction),
+      sourcepos: convert(document.sourcepos, direction)
+    }
+  end
 
-      :error ->
-        raise ArgumentError, "cannot convert #{inspect(module)}"
+  defp convert(%MDEx.Document{} = document, :from_mdex = direction) do
+    %MDExNative.Comrak.Document{
+      nodes: convert(document.nodes, direction),
+      sourcepos: convert(document.sourcepos, direction)
+    }
+  end
+
+  defp convert(%module{} = node, direction) do
+    {target, size} = translate!(module, direction)
+
+    node
+    |> rename(target, size)
+    |> convert_nested(:nodes, direction)
+    |> convert_nested(:sourcepos, direction)
+    |> convert_nested(:attrs, direction)
+  end
+
+  defp convert(value, _direction), do: value
+
+  # A node decoded by a mismatched `mdex_native` may be missing fields this version
+  # knows about, so only swap `__struct__` when both structs are the same shape.
+  defp rename(node, target, size) when map_size(node) == size, do: Map.replace!(node, :__struct__, target)
+  defp rename(node, target, _size), do: struct(target, Map.from_struct(node))
+
+  defp convert_nested(node, key, direction) do
+    case node do
+      %{^key => nil} -> node
+      %{^key => value} -> %{node | key => convert(value, direction)}
+      _ -> node
     end
   end
 
-  defp convert(value, _from, _to), do: value
+  for name <- @nodes do
+    native = Module.concat(MDExNative.Comrak, name)
+    mdex = Module.concat(MDEx, name)
+    size = map_size(native.__struct__())
 
-  defp convert_module(module, from, to) do
-    parts = Module.split(module)
-
-    case Enum.split(parts, length(from)) do
-      {^from, [_name]} ->
-        {:ok, Module.safe_concat([to, List.last(parts)])}
-
-      _ ->
-        :error
-    end
+    defp translate!(unquote(native), :to_mdex), do: {unquote(mdex), unquote(size)}
+    defp translate!(unquote(mdex), :from_mdex), do: {unquote(native), unquote(size)}
   end
+
+  defp translate!(module, _direction), do: raise(ArgumentError, "cannot convert #{inspect(module)}")
 end

--- a/lib/mdex/comrak_converter.ex
+++ b/lib/mdex/comrak_converter.ex
@@ -1,11 +1,9 @@
 defmodule MDEx.ComrakConverter do
   @moduledoc false
 
-  # Both namespaces declare the same fields, so a node converts by swapping `__struct__`.
-  # `Document` is excluded: `MDEx.Document` also carries pipeline state.
   @nodes ~w(
     Alert Attributes BlockDirective BlockQuote Code CodeBlock DescriptionDetails
-    DescriptionItem DescriptionList DescriptionTerm Emph Escaped EscapedTag
+    DescriptionItem DescriptionList DescriptionTerm Document Emph Escaped EscapedTag
     FootnoteDefinition FootnoteReference FrontMatter Heading HeexBlock HeexInline
     Highlight HtmlBlock HtmlInline Image Insert LineBreak Link List ListItem Math
     MultilineBlockQuote Paragraph Raw ShortCode SoftBreak Sourcepos SpoileredText
@@ -18,51 +16,34 @@ defmodule MDEx.ComrakConverter do
 
   defp convert(nodes, direction) when is_list(nodes), do: Enum.map(nodes, &convert(&1, direction))
 
-  defp convert(%MDExNative.Comrak.Document{} = document, :to_mdex = direction) do
-    %MDEx.Document{
-      nodes: convert(document.nodes, direction),
-      sourcepos: convert(document.sourcepos, direction)
-    }
-  end
-
-  defp convert(%MDEx.Document{} = document, :from_mdex = direction) do
-    %MDExNative.Comrak.Document{
-      nodes: convert(document.nodes, direction),
-      sourcepos: convert(document.sourcepos, direction)
-    }
-  end
-
   defp convert(%module{} = node, direction) do
-    {target, size} = translate!(module, direction)
+    target = translate!(module, direction)
 
-    node
-    |> rename(target, size)
-    |> convert_nested(:nodes, direction)
-    |> convert_nested(:sourcepos, direction)
-    |> convert_nested(:attrs, direction)
+    fields =
+      node
+      |> Map.from_struct()
+      |> convert_nested(:nodes, direction)
+      |> convert_nested(:sourcepos, direction)
+      |> convert_nested(:attrs, direction)
+
+    struct(target, fields)
   end
 
   defp convert(value, _direction), do: value
 
-  # Sizes differ when `mdex_native` decoded a different set of fields.
-  defp rename(node, target, size) when map_size(node) == size, do: Map.replace!(node, :__struct__, target)
-  defp rename(node, target, _size), do: struct(target, Map.from_struct(node))
-
-  defp convert_nested(node, key, direction) do
-    case node do
-      %{^key => nil} -> node
-      %{^key => value} -> %{node | key => convert(value, direction)}
-      _ -> node
+  defp convert_nested(fields, key, direction) do
+    case fields do
+      %{^key => value} -> %{fields | key => convert(value, direction)}
+      _ -> fields
     end
   end
 
   for name <- @nodes do
     native = Module.concat(MDExNative.Comrak, name)
     mdex = Module.concat(MDEx, name)
-    size = map_size(native.__struct__())
 
-    defp translate!(unquote(native), :to_mdex), do: {unquote(mdex), unquote(size)}
-    defp translate!(unquote(mdex), :from_mdex), do: {unquote(native), unquote(size)}
+    defp translate!(unquote(native), :to_mdex), do: unquote(mdex)
+    defp translate!(unquote(mdex), :from_mdex), do: unquote(native)
   end
 
   defp translate!(module, _direction), do: raise(ArgumentError, "cannot convert #{inspect(module)}")

--- a/lib/mdex/document.ex
+++ b/lib/mdex/document.ex
@@ -2278,7 +2278,7 @@ defmodule MDEx.Document do
 
   @doc false
   def unparsed_markdown(%MDEx.Document{nodes: [], buffer: [_ | _] = buffer, current_steps: [], halted: false} = document) do
-    if get_private(document, :fragment_completion, false) do
+    if get_private(document, :auto_close, false) do
       :error
     else
       {:ok, buffer_to_binary(buffer)}

--- a/lib/mdex/document.ex
+++ b/lib/mdex/document.ex
@@ -2277,7 +2277,6 @@ defmodule MDEx.Document do
   end
 
   @doc false
-  # Buffered Markdown that is the document's whole content, so it can render without an AST.
   def unparsed_markdown(%MDEx.Document{nodes: [], buffer: [_ | _] = buffer, current_steps: [], halted: false} = document) do
     if get_private(document, :fragment_completion, false) do
       :error

--- a/lib/mdex/document.ex
+++ b/lib/mdex/document.ex
@@ -2277,9 +2277,7 @@ defmodule MDEx.Document do
   end
 
   @doc false
-  # Markdown waiting to be parsed, when it is the document's whole content: nothing
-  # already parsed to merge it with, no steps to run over the resulting AST and no
-  # fragment completion to apply. Callers can render it without building an AST.
+  # Buffered Markdown that is the document's whole content, so it can render without an AST.
   def unparsed_markdown(%MDEx.Document{nodes: [], buffer: [_ | _] = buffer, current_steps: [], halted: false} = document) do
     if get_private(document, :fragment_completion, false) do
       :error

--- a/lib/mdex/document.ex
+++ b/lib/mdex/document.ex
@@ -2276,6 +2276,20 @@ defmodule MDEx.Document do
     end
   end
 
+  @doc false
+  # Markdown waiting to be parsed, when it is the document's whole content: nothing
+  # already parsed to merge it with, no steps to run over the resulting AST and no
+  # fragment completion to apply. Callers can render it without building an AST.
+  def unparsed_markdown(%MDEx.Document{nodes: [], buffer: [_ | _] = buffer, current_steps: [], halted: false} = document) do
+    if get_private(document, :fragment_completion, false) do
+      :error
+    else
+      {:ok, buffer_to_binary(buffer)}
+    end
+  end
+
+  def unparsed_markdown(%MDEx.Document{}), do: :error
+
   defp buffer_to_binary(buffer) do
     buffer
     |> Enum.reverse()

--- a/test/mdex/comrak_converter_test.exs
+++ b/test/mdex/comrak_converter_test.exs
@@ -119,16 +119,28 @@ defmodule MDEx.ComrakConverterTest do
   end
 
   test "round-trips every struct MDExNative.Comrak defines" do
-    Application.load(:mdex_native)
-    {:ok, modules} = :application.get_key(:mdex_native, :modules)
+    natives = native_structs()
 
-    for module <- modules, ["MDExNative", "Comrak", suffix] <- [Module.split(module)] do
+    # A partial module list would let the round trip below pass without asserting anything.
+    assert Enum.all?(@nodes, &(Module.concat(MDExNative.Comrak, &1) in natives))
+
+    for module <- natives do
+      ["MDExNative", "Comrak", suffix] = Module.split(module)
       native = module.__struct__()
       mdex = MDEx.ComrakConverter.to_mdex(native)
 
       assert mdex.__struct__ == Module.concat(MDEx, suffix)
       assert MDEx.ComrakConverter.from_mdex(mdex) == native
     end
+  end
+
+  defp native_structs do
+    :ok = Application.ensure_loaded(:mdex_native)
+
+    for module <- Application.spec(:mdex_native, :modules),
+        match?(["MDExNative", "Comrak", _suffix], Module.split(module)),
+        Code.ensure_loaded?(module) and function_exported?(module, :__struct__, 0),
+        do: module
   end
 
   defp fields(module) do

--- a/test/mdex/comrak_converter_test.exs
+++ b/test/mdex/comrak_converter_test.exs
@@ -121,7 +121,7 @@ defmodule MDEx.ComrakConverterTest do
   test "round-trips every struct MDExNative.Comrak defines" do
     natives = native_structs()
 
-    # A partial module list would let the round trip below pass without asserting anything.
+    # A partial list would let the loop below assert nothing.
     assert Enum.all?(@nodes, &(Module.concat(MDExNative.Comrak, &1) in natives))
 
     for module <- natives do

--- a/test/mdex/comrak_converter_test.exs
+++ b/test/mdex/comrak_converter_test.exs
@@ -121,7 +121,7 @@ defmodule MDEx.ComrakConverterTest do
   test "round-trips every struct MDExNative.Comrak defines" do
     natives = native_structs()
 
-    # A partial list would let the loop below assert nothing.
+    # Or the loop below asserts nothing.
     assert Enum.all?(@nodes, &(Module.concat(MDExNative.Comrak, &1) in natives))
 
     for module <- natives do

--- a/test/mdex/comrak_converter_test.exs
+++ b/test/mdex/comrak_converter_test.exs
@@ -118,6 +118,19 @@ defmodule MDEx.ComrakConverterTest do
     end
   end
 
+  test "round-trips every struct MDExNative.Comrak defines" do
+    Application.load(:mdex_native)
+    {:ok, modules} = :application.get_key(:mdex_native, :modules)
+
+    for module <- modules, ["MDExNative", "Comrak", suffix] <- [Module.split(module)] do
+      native = module.__struct__()
+      mdex = MDEx.ComrakConverter.to_mdex(native)
+
+      assert mdex.__struct__ == Module.concat(MDEx, suffix)
+      assert MDEx.ComrakConverter.from_mdex(mdex) == native
+    end
+  end
+
   defp fields(module) do
     module.__struct__()
     |> Map.from_struct()

--- a/test/mdex/comrak_converter_test.exs
+++ b/test/mdex/comrak_converter_test.exs
@@ -143,8 +143,6 @@ defmodule MDEx.ComrakConverterTest do
   end
 
   defp native_structs do
-    :ok = Application.ensure_loaded(:mdex_native)
-
     for module <- Application.spec(:mdex_native, :modules),
         match?(["MDExNative", "Comrak", _suffix], Module.split(module)),
         Code.ensure_loaded?(module) and function_exported?(module, :__struct__, 0),

--- a/test/mdex/comrak_converter_test.exs
+++ b/test/mdex/comrak_converter_test.exs
@@ -89,6 +89,16 @@ defmodule MDEx.ComrakConverterTest do
              MDEx.ComrakConverter.to_mdex(native_code)
   end
 
+  test "rebuilds structs when source and target fields differ" do
+    native_code =
+      %MDExNative.Comrak.Code{literal: "elixir"}
+      |> Map.delete(:attrs)
+      |> Map.put(:future_field, true)
+
+    assert %MDEx.Code{literal: "elixir", attrs: nil} =
+             MDEx.ComrakConverter.to_mdex(native_code)
+  end
+
   test "converts mdex document structs to native structs" do
     document = %MDEx.Document{
       nodes: [
@@ -120,9 +130,7 @@ defmodule MDEx.ComrakConverterTest do
 
   test "round-trips every struct MDExNative.Comrak defines" do
     natives = native_structs()
-
-    # Or the loop below asserts nothing.
-    assert Enum.all?(@nodes, &(Module.concat(MDExNative.Comrak, &1) in natives))
+    refute Enum.empty?(natives)
 
     for module <- natives do
       ["MDExNative", "Comrak", suffix] = Module.split(module)

--- a/test/mdex/html_format_test.exs
+++ b/test/mdex/html_format_test.exs
@@ -669,4 +669,27 @@ defmodule MDEx.HTMLFormatTest do
       block_directive: true
     )
   end
+
+  describe "rendering without an AST" do
+    @markdown "# Title\n\nSome **bold** text with `code` and a [link](http://example.com).\n"
+
+    test "renders the same HTML as the pipeline" do
+      with_step = MDEx.Document.append_steps(MDEx.new(markdown: @markdown), noop: & &1)
+
+      assert MDEx.to_html!(@markdown) == MDEx.to_html!(with_step)
+    end
+
+    test "still runs pipeline steps" do
+      upcase = &MDEx.Document.update_nodes(&1, MDEx.Text, fn node -> %{node | literal: String.upcase(node.literal)} end)
+      document = MDEx.Document.append_steps(MDEx.new(markdown: @markdown), upcase: upcase)
+
+      assert MDEx.to_html!(document) =~ "<h1>TITLE</h1>"
+    end
+
+    test "still renders documents that were already parsed" do
+      document = %MDEx.Document{nodes: [%MDEx.Paragraph{nodes: [%MDEx.Text{literal: "parsed"}]}]}
+
+      assert MDEx.to_html!(document) == "<p>parsed</p>"
+    end
+  end
 end

--- a/test/mdex/html_format_test.exs
+++ b/test/mdex/html_format_test.exs
@@ -40,10 +40,11 @@ defmodule MDEx.HTMLFormatTest do
       render: [unsafe: true]
     ]
 
+    assert {:ok, direct_html} = MDEx.to_html(document, opts)
     assert {:ok, doc} = MDEx.parse_document(document, opts)
     assert {:ok, html} = MDEx.to_html(doc, opts)
 
-    # IO.puts(html)
+    assert direct_html == html
     assert html == String.trim(expected)
   end
 
@@ -54,10 +55,11 @@ defmodule MDEx.HTMLFormatTest do
       render: [unsafe: true]
     ]
 
+    assert {:ok, direct_html} = MDEx.to_html(document, opts)
     assert {:ok, doc} = MDEx.parse_document(document, opts)
     assert {:ok, html} = MDEx.to_html(doc, opts)
 
-    # IO.puts(html)
+    assert direct_html == html
     assert html == String.trim(expected)
   end
 
@@ -677,6 +679,16 @@ defmodule MDEx.HTMLFormatTest do
       with_step = MDEx.Document.append_steps(MDEx.new(markdown: @markdown), noop: & &1)
 
       assert MDEx.to_html!(@markdown) == MDEx.to_html!(with_step)
+    end
+
+    test "preserves buffered Markdown order" do
+      document =
+        MDEx.new(markdown: "# Last")
+        |> MDEx.Document.put_markdown("# First\n", :top)
+
+      with_step = MDEx.Document.append_steps(document, noop: & &1)
+
+      assert MDEx.to_html!(document) == MDEx.to_html!(with_step)
     end
 
     test "still runs pipeline steps" do

--- a/test/mdex/xml_format_test.exs
+++ b/test/mdex/xml_format_test.exs
@@ -114,4 +114,11 @@ defmodule MDEx.XmlFormatTest do
       subtext: true
     )
   end
+
+  test "renders the same XML from Markdown and from a document" do
+    markdown = "# Hello\n"
+    options = [render: [sourcepos: true]]
+
+    assert MDEx.to_xml!(markdown, options) == MDEx.to_xml!(MDEx.new([markdown: markdown] ++ options))
+  end
 end

--- a/test/mdex/xml_format_test.exs
+++ b/test/mdex/xml_format_test.exs
@@ -114,11 +114,4 @@ defmodule MDEx.XmlFormatTest do
       subtext: true
     )
   end
-
-  test "renders the same XML from Markdown and from a document" do
-    markdown = "# Hello\n"
-    options = [render: [sourcepos: true]]
-
-    assert MDEx.to_xml!(markdown, options) == MDEx.to_xml!(MDEx.new([markdown: markdown] ++ options))
-  end
 end


### PR DESCRIPTION
Closes #395.

No public behavior change is intended.

`MDEx.to_html/2` spent most of its time translating the AST between the `MDEx.*` and `MDExNative.Comrak.*` namespaces twice per render.

### What changed

- `MDEx.ComrakConverter` now resolves matching modules through compile-time function clauses instead of `Module.split/1` and `Module.safe_concat/1`. It still rebuilds every target with `struct/2`, preserving defaults and ignoring unknown fields when the two struct definitions differ.
- Eligible HTML renders pass untouched buffered Markdown directly to `MDExNative.Comrak.markdown_to_html/2`, avoiding both AST translations.
- The established AST path remains in place for `auto_close`, deprecated `streaming`, pipeline steps, code-fence renderers, parsed or halted documents, XML, and CommonMark.

### Performance

26 KB inline-heavy document with syntax highlighting disabled, on OTP 29.0.5 / Elixir 1.20.4. `main` and the PR were archived into separate source trees with byte-identical lockfiles and isolated build directories. Each range contains the median from two independent processes run in reverse revision order; each process used 25 warm-ups followed by 11 batches of 40 renders.

| path | `main` | PR | speedup |
| --- | ---: | ---: | ---: |
| Markdown → HTML | 41.74–43.99 ms | 1.126 ms | 37–39× |
| no-op pipeline → HTML | 43.03–43.90 ms | 14.29–14.58 ms | 3.0× |
| parsed AST → HTML | 21.25–21.97 ms | 7.64–7.97 ms | 2.7–2.9× |

Every measured path produced the same 57,459-byte output with the same SHA-256 digest. The benchmarked PR runtime tree is byte-identical to the current head; the only later change removed an unnecessary call from a test.

### Compatibility verification

- 844 tests pass on Elixir 1.15 / OTP 25.1, Elixir 1.20.4 / OTP 29, and Elixir main / OTP 29.
- 5,400 direct-vs-AST comparisons across tracked Markdown and Livebook files, edge cases, deterministic generated Markdown, and ten option groups produced identical HTML.
- Regression coverage keeps `auto_close`, deprecated `streaming`, pipeline steps, code-fence renderers, parsed documents, halted documents, buffered-input ordering, and XML/CommonMark on their prior paths.
- Converter tests cover every native Comrak struct and mismatched source/target fields.
- Formatting, `mix credo --strict`, and `git diff --check` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `auto_close` document option for controlling whether incomplete Markdown syntax is closed at the end of a buffer.
  * Added support for retrieving buffered, unparsed Markdown when the document is eligible.
  * HTML rendering can now process eligible unparsed Markdown directly for improved performance.

* **Bug Fixes**
  * Improved conversion of supported document elements while preserving attributes and nested content.
  * Rendering now more consistently handles buffered Markdown, halted documents, and appended processing steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->